### PR TITLE
Issues #39 and #237 dealt with

### DIFF
--- a/my/XRX/src/mom/app/charters/chimport.xqm
+++ b/my/XRX/src/mom/app/charters/chimport.xqm
@@ -28,6 +28,8 @@ import module namespace charters="http://www.monasterium.net/NS/charters"
     at "../charters/charters.xqm";
 import module namespace metadata="http://www.monasterium.net/NS/metadata"
     at "../metadata/metadata.xqm";
+import module namespace conf="http://www.monasterium.net/NS/conf"
+    at "../xrx/conf.xqm";
 
 declare namespace xf="http://www.w3.org/2002/xforms";
 declare namespace ev="http://www.w3.org/2001/xml-events";
@@ -131,22 +133,31 @@ declare function chimport:publish-charters-model(
 
 declare function chimport:remove-charters-model(
     $request-root as xs:string,
-    $xrx-import-xml as element(xrx:import)) as element() {
+    $xrx-import-xml as element(xrx:import),
+    $imported-collection-cacheid as xs:string) as element() {
 
     <xf:model id="mremove-charters">
     
-        <xf:instance>{ $xrx-import-xml }</xf:instance>
+        <xf:instance>
+        	<any_wrapper>
+        		<cacheid>{ $imported-collection-cacheid }</cacheid>
+        		<processid>pidremove-charters</processid>
+        		{ $xrx-import-xml }
+        	</any_wrapper>
+        </xf:instance>
 
         <xf:submission id="sremove-charters" 
             action="{ $request-root }service/remove-charters" 
             method="post" 
             replace="none">
+            <!--
             <xf:action ev:event="xforms-submit-error">
                 <xf:message level="ephemeral">ERROR</xf:message>
             </xf:action>
             <xf:action ev:event="xforms-submit-done">
                 <xf:message level="ephemeral">OK</xf:message>
             </xf:action>
+            -->
         </xf:submission>
         
         <xf:action ev:event="xforms-ready">
@@ -158,7 +169,8 @@ declare function chimport:remove-charters-model(
 
 declare function chimport:remove-charters-trigger(
     $remove-charters-message as element(xhtml:span),
-    $context as xs:string) as element() {
+    $context as xs:string,
+    $imported-collection-cacheid) as element() {
     
     <xf:group model="mremove-charters">
         <xf:trigger appearance="minimal">
@@ -166,6 +178,16 @@ declare function chimport:remove-charters-trigger(
                 <span>‣&#160;</span>
                 { $remove-charters-message }
             </xf:label>
+            <xf:action ev:event="DOMActivate">
+              <script type="text/javascript">
+                /* Using the import-progress service here, because service-wise it doesn't matter, if the progress is for import or remove. Functionality is the same. */
+                jQuery('#progressbar-remove').progressbarRemove({{
+                            serviceUrlRemoveProgress: "{ conf:param('request-root') }service/import-progress",
+                            cacheId: "{ $imported-collection-cacheid }",
+                            processId: "pidremove-charters"
+                          }}).progressbar( "value", 0 ).progressbarRemove( "progress" );
+              </script>
+            </xf:action>
             <bfc:show dialog="remove-charters-dialog" ev:event="DOMActivate"/>
         </xf:trigger>
         <bfc:dialog id="remove-charters-dialog">
@@ -191,9 +213,16 @@ declare function chimport:remove-charters-trigger(
                                       <xf:resource value="'{ $context }'"/>
                                     </xf:load>
                                 </xf:action>
-                                <bfc:hide dialog="remove-charters-dialog" ev:event="DOMActivate"/>
                             </xf:trigger>
                         </td>
+                    </tr>
+                    <tr>
+                      <fieldset>
+                        <legend>
+                          Status
+                        </legend>
+                        <div data-demoid="e1a6f131-3aa1-49e9-bbd5-c0a28c2783c9" id="progressbar-remove"><div class="progress-label" data-demoid="66e8417d-6d6b-4829-b75e-4245bd95442a">0%</div></div>
+                      </fieldset>
                     </tr>
                 </table>
             </div>

--- a/my/XRX/src/mom/app/charters/service/remove-charters.service.xml
+++ b/my/XRX/src/mom/app/charters/service/remove-charters.service.xml
@@ -30,6 +30,15 @@ You should have received a copy of the GNU General Public License
 along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
   </xrx:licence>
   <xrx:variables>
+  <!-- $cacheid and $processid provided to this service via post-request. Basically made them up. -->
+    <xrx:variable>
+      <xrx:name>$cacheid</xrx:name>
+      <xrx:expression>xs:string($data//*:cacheid/text())</xrx:expression>
+    </xrx:variable>
+    <xrx:variable>
+      <xrx:name>$processid</xrx:name>
+      <xrx:expression>xs:string($data//*:processid/text())</xrx:expression>
+    </xrx:variable>
     <xrx:variable>
       <xrx:name>$context</xrx:name>
       <xrx:expression>xs:string($data//xrx:context/text())</xrx:expression>
@@ -58,6 +67,16 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
       <xrx:name>$charters-import-collection-path</xrx:name>
       <xrx:expression>concat(conf:param('atom-db-base-uri'), $charters-import-feed)</xrx:expression>
     </xrx:variable>
+    <!-- the actual collection obtained from the collection path. -->
+    <xrx:variable>
+      <xrx:name>$charters-import-collection</xrx:name>
+      <xrx:expression>collection($charters-import-collection-path)</xrx:expression>
+    </xrx:variable>
+    <!-- the amount of charters inside the collection that is going to be deleted -->
+    <xrx:variable>
+      <xrx:name>$charters-import-amount-of-charters</xrx:name>
+      <xrx:expression>count($charters-import-collection)</xrx:expression>
+    </xrx:variable>
   </xrx:variables>
   <xrx:init>
    <xrx:processor>
@@ -66,10 +85,52 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
   </xrx:init>
   <xrx:body>
     {
-    let $remove-imported-charters := 
-      if((($archid != '' and $fondid != '') or $collectionid != '')) then xmldb:remove($charters-import-collection-path) else()
-    return
-    ()
+
+    let $progress1 :=
+    <xrx:progress>
+      <xrx:cacheid>{ $cacheid }</xrx:cacheid>
+      <xrx:processid>{ $processid }</xrx:processid>
+      <xrx:actual>0</xrx:actual>
+      <xrx:total>0</xrx:total>
+      <xrx:message>Preparing charters...</xrx:message>
+    </xrx:progress>
+    let $cache := cache:put($cacheid, $processid, $progress1)
+    let $wait := util:wait(2000)
+
+		    (: removing the charters one by one, to be able to have a progress bar.
+		     ~ When only calling xmldb:remove once for the entire collection, we are blind to the actual operation until it is finished.
+		     :)
+    let $do-remove :=
+		    (: loop through all the charters in the collection. Provide the xrx:progress element,
+		     ~ put it inside the cache with cache:put, so the javascript code can request periodical updates.
+		     :)
+	   if((($archid != '' and $fondid != '') or $collectionid != '')) then
+		    for $charter-to-remove at $pos in $charters-import-collection
+		      let $charter-document-uri := document-uri($charter-to-remove)
+		      (: let $debug1 := util:log("error", concat('DOCURI: ',$charter-document-uri)) :)
+		      let $remove-imported-charter := xmldb:remove($charters-import-collection-path, tokenize($charter-document-uri, '/')[last()])
+		      let $progress2 :=
+			      <xrx:progress>
+			        <xrx:cacheid>{ $cacheid }</xrx:cacheid>
+			        <xrx:processid>{ $processid }</xrx:processid>
+			        <xrx:actual>{ $pos }</xrx:actual>
+			        <xrx:total>{ $charters-import-amount-of-charters }</xrx:total>
+			        <xrx:message></xrx:message>
+			      </xrx:progress>
+			    let $cache := cache:put($cacheid, $processid, $progress2)
+			    return true()
+		  else ()
+
+		(: clear cache after 2 seconds :)
+		let $wait_a_moment := util:wait(2000)
+    let $clear-cache := cache:clear($cacheid)
+
+    (: also remove the now empty collection, so it does not stay around in the database. :)
+    let $remove-empty-imported-charters-collection := if((($archid != '' and $fondid != '') or $collectionid != '')) then xmldb:remove($charters-import-collection-path) else()
+
+	  return
+	  ()
+
     }
   </xrx:body>
 </xrx:service>

--- a/my/XRX/src/mom/app/charters/service/remove-charters.service.xml
+++ b/my/XRX/src/mom/app/charters/service/remove-charters.service.xml
@@ -121,12 +121,12 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
 			    return true()
 		  else ()
 
-		(: clear cache after 2 seconds :)
+		(: clear cache after 2 seconds, so the Javascript gets its chance to notice the 100 % status while calling only every other second. :)
 		let $wait_a_moment := util:wait(2000)
     let $clear-cache := cache:clear($cacheid)
 
-    (: also remove the now empty collection, so it does not stay around in the database. :)
-    let $remove-empty-imported-charters-collection := if((($archid != '' and $fondid != '') or $collectionid != '')) then xmldb:remove($charters-import-collection-path) else()
+    (: The collection is not removed, even though it is empty, because removing the collection is handled in a different workflow. Left in here as a little stub... :)
+    (: let $remove-empty-imported-charters-collection := if((($archid != '' and $fondid != '') or $collectionid != '')) then xmldb:remove($charters-import-collection-path) else() :)
 
 	  return
 	  ()

--- a/my/XRX/src/mom/app/collection/collection.app.xml
+++ b/my/XRX/src/mom/app/collection/collection.app.xml
@@ -102,6 +102,12 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
       <xrx:relativepath>js/</xrx:relativepath>
       <xrx:name>jquery.ui.myCollectionsEdit.js</xrx:name>
     </xrx:resource>
+    <!--  JavaScript -->
+    <xrx:resource>
+      <xrx:atomid>tag:www.monasterium.net,2011:/mom/resource/jquery/ui/progressbarRemove</xrx:atomid>
+      <xrx:relativepath>js/</xrx:relativepath>
+      <xrx:name>jquery.ui.progressbarRemove.js</xrx:name>
+    </xrx:resource>
   </xrx:resources>
   <xrx:resolver>
     <!-- services -->

--- a/my/XRX/src/mom/app/collection/js/jquery.ui.progressbarRemove.js
+++ b/my/XRX/src/mom/app/collection/js/jquery.ui.progressbarRemove.js
@@ -1,0 +1,63 @@
+/*!
+ * jQuery UI XRX Tabs
+ *
+ * Depends:
+ *   jquery.ui.tabs.js
+ */
+(function( $, undefined ) {
+
+$.widget( "ui.progressbarRemove", {
+
+	options: {
+		serviceUrlRemoveProgress: "",
+		cacheId: "",
+		processId: ""
+	},
+
+	_create: function() {
+
+		var self = this;
+
+		self.label = $(".progress-label", "#" + $(self.element[0]).attr("id"));
+
+		self.progbar = self.element.progressbar({
+			value: false,
+			change: function() {
+				self.label.text( self.progbar.progressbar( "value" ) + "%" );
+			}
+		});
+	},
+
+	progress: function() {
+
+		var self = this;
+
+		$.ajax({
+			url: self.options.serviceUrlRemoveProgress,
+			contentType: "application/xml",
+			type: "POST",
+			data: '<xrx:progress xmlns:xrx="http://www.monasterium.net/NS/xrx"><xrx:cacheid>' + self.options.cacheId + '</xrx:cacheid><xrx:processid>' + self.options.processId + '</xrx:processid></xrx:progress>',
+			complete: function(data, textStatus, jqXHR) {
+				var json = jQuery.parseJSON(data.responseText);
+				var actual = parseInt(json["actual"]);
+				var total = parseInt(json["total"]);
+				var message = json["message"] || "";
+				var val;
+
+				if(total == 0) { val = 0; }
+				else { val = Math.round(((actual / total) * 100)); }
+
+				if(message != "") { self.label.text(message); }
+				else { self.progbar.progressbar( "value", val ); }
+
+				if ( val != 100 ) {
+					window.setTimeout( function() { self.progress() }, 1000 );
+				}
+			}
+		});
+
+	}
+
+});
+
+})( jQuery );

--- a/my/XRX/src/mom/app/collection/widget/imported-collection.widget.xml
+++ b/my/XRX/src/mom/app/collection/widget/imported-collection.widget.xml
@@ -64,6 +64,16 @@ it leaves the active development stage.
       <xrx:name>$wcharters:metadata-charter-collection</xrx:name>
       <xrx:expression>metadata:base-collection('charter', $charter:rcollectionid, 'import')</xrx:expression>
     </xrx:variable>
+    <!-- cache info preparation -->
+    <xrx:variable>
+      <xrx:name>$wimported-collection:uri-tokens</xrx:name>
+      <xrx:expression>charters:ruri-tokens()</xrx:expression>
+    </xrx:variable>
+    <!-- cache info -->
+    <xrx:variable>
+      <xrx:name>$wimported-collection:cacheid</xrx:name> <!-- the cacheid should come out as e.g. 'tag:www.monasterium.net,2011:/cache/firstcollection/imported-collection' -->
+      <xrx:expression>metadata:atomid('cache', ($wimported-collection:uri-tokens, $xrx:tokenized-uri[last()]))</xrx:expression>
+    </xrx:variable>
     <!-- block-wise navigation -->
     <xrx:variable>
       <xrx:name>$wcharters:preface-exists</xrx:name>
@@ -97,8 +107,16 @@ it leaves the active development stage.
   <xrx:init>
     <xrx:processor>
       <xrx:xformsflag>true</xrx:xformsflag>
+      <xrx:jqueryflag>true</xrx:jqueryflag>
     </xrx:processor>
   </xrx:init>
+  <xrx:jss>
+    <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/jquery</xrx:resource>
+    <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/ui/core</xrx:resource>
+    <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/ui/widget</xrx:resource>
+    <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/ui/progressbar</xrx:resource>
+    <xrx:resource>tag:www.monasterium.net,2011:/mom/resource/jquery/ui/progressbarRemove</xrx:resource>
+  </xrx:jss>
   <xrx:model>
     {
     let $metadata-charter-collection := metadata:base-collection('charter', $charter:rcollectionid, 'import')
@@ -106,7 +124,7 @@ it leaves the active development stage.
     return
     (
     chimport:publish-charters-model(conf:param('request-root'), $xrx-import-xml),
-    chimport:remove-charters-model(conf:param('request-root'), $xrx-import-xml)
+    chimport:remove-charters-model(conf:param('request-root'), $xrx-import-xml, $wimported-collection:cacheid)
     )
     }
   </xrx:model>
@@ -193,7 +211,8 @@ it leaves the active development stage.
                           <xrx:default>Remove imported charters</xrx:default>
                         </xrx:i18n>
                       </span>,
-                      'collection'
+                      'collection',
+                      $wimported-collection:cacheid
                       )
                       }
                     </div>

--- a/my/XRX/src/mom/app/fond/widget/edit-fond.widget.xml
+++ b/my/XRX/src/mom/app/fond/widget/edit-fond.widget.xml
@@ -101,18 +101,9 @@
                             <a href="{concat(conf:param('request-root'), $archive-id, '/' , $fond-id, '/fond') }">{ $fond-id }</a>
                         </div>
                         
-                        let $server := substring-before(request:get-url(), conf:param('request-root'))					
+                        let $server := substring-before($xrx:jetty-request-base-url, conf:param('request-root'))
                         
-                        (:Dirty HACK : just atom-url doesn't work as resource when using an apache:)
-                        let $servername := request:get-server-name()
-                        let $server := 
-                        if($servername = 'monasterium.net') then
-                        concat('http://ftp.dioezesanarchiv.acw.at:8181', conf:param('request-root'))
-                        else if ($servername = 'vdu.uni-koeln.de') then
-                        concat('http://ftp.dioezesanarchiv.acw.at:8585', conf:param('request-root'))					  
-                        else 
-                        ''
-                        
+                        (: This $get-uri is probably not used at all anywhere? Does not do harm at the moment. Remains of sloppy-style... :)
                         let $get-uri := concat(substring-before(request:get-url(), conf:param('request-root')), conf:param('request-root'),'atom/GET',metadata:feed('fond', ($archive-id, $fond-id), 'public'),'/', $fond-id, '.ead.xml')
                   
                         

--- a/my/XRX/system/config/db/mom-data/metadata.charter.public/collection.xconf
+++ b/my/XRX/system/config/db/mom-data/metadata.charter.public/collection.xconf
@@ -1,12 +1,84 @@
 <collection xmlns="http://exist-db.org/collection-config/1.0"> 
-    <index xmlns:cei="http://www.monasterium.net/NS/cei" xmlns:atom="http://www.w3.org/2005/Atom"> 
-        <fulltext default="none" attributes="no"/>
+    <index xmlns:cei="http://www.monasterium.net/NS/cei">
         <lucene> 
             <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/> 
-            <text qname="cei:text"/> 
+            <text qname="cei:abstract"/>
+            <text qname="cei:altIdentifier"/>
+            <text qname="cei:apprecatio"/>
+            <text qname="cei:arch"/>
+            <text qname="cei:archFond"/>
+            <text qname="cei:archIdentifier"/>
+            <text qname="cei:arenga"/>
+            <text qname="cei:auth"/>
+            <text qname="cei:class"/>
+            <text qname="cei:condition"/>
+            <text qname="cei:corroboratio"/>
+            <text qname="cei:country"/>
+            <text qname="cei:datatio"/>
+            <text qname="cei:date"/>
+            <text qname="cei:dateRange"/>
+            <text qname="cei:dimensions"/>
+            <text qname="cei:dispositio"/>
+            <text qname="cei:divNotes"/>
+            <text qname="cei:figDesc"/>
+            <text qname="cei:geogName"/>
+            <text qname="cei:idno"/>
+            <text qname="cei:index"/>
+            <text qname="cei:inscriptio"/>
+            <text qname="cei:intitulatio"/>
+            <text qname="cei:invocatio"/>
+            <text qname="cei:issuer"/>
+            <text qname="cei:lang_MOM"/>
+            <text qname="cei:legend"/>
+            <text qname="cei:listBibl"/>
+            <text qname="cei:listBiblEdition"/>
+            <text qname="cei:listBiblErw"/>
+            <text qname="cei:listBiblFaksimile"/>
+            <text qname="cei:listBiblRegest"/>
+            <text qname="cei:material"/>
+            <text qname="cei:msIdentifier"/>
+            <text qname="cei:narratio"/>
+            <text qname="cei:nota"/>
+            <text qname="cei:notariusDesc"/>
+            <text qname="cei:notariusSign"/>
+            <text qname="cei:notariusSub"/>
+            <text qname="cei:note"/>
+            <text qname="cei:persName"/>
+            <text qname="cei:physicalDesc"/>
+            <text qname="cei:placeName"/>
+            <text qname="cei:publicatio"/>
+            <text qname="cei:quoteOriginaldatierung"/>
+            <text qname="cei:recipient"/>
+            <text qname="cei:region"/>
+            <text qname="cei:sanctio"/>
+            <text qname="cei:seal"/>
+            <text qname="cei:sealCondition"/>
+            <text qname="cei:sealDesc"/>
+            <text qname="cei:sealDimensions"/>
+            <text qname="cei:sealMaterial"/>
+            <text qname="cei:setPhrase"/>
+            <text qname="cei:settlement"/>
+            <text qname="cei:sigillant"/>
+            <text qname="cei:sourceDescRegest"/>
+            <text qname="cei:sourceDescVolltext"/>
+            <text qname="cei:subscriptio"/>
+            <text qname="cei:tenor"/>
+            <text qname="cei:testis"/>
+            <text qname="cei:text"/>
+            <text qname="cei:traditioForm"/>
+            <text qname="cei:witListPar"/>
+            <text qname="cei:witnessOrig"/>
+            <inline qname="cei:add"/>
+            <inline qname="cei:cit"/>
+            <inline qname="cei:del"/>
+            <inline qname="cei:sup"/>
+            <inline qname="cei:expan"/>
         </lucene>
         <create qname="@from" type="xs:integer"/>
         <create qname="@to" type="xs:integer"/>
         <create qname="@value" type="xs:integer"/>
-    </index> 
+    </index>
+    <triggers>
+        <trigger class="org.exist.extensions.exquery.restxq.impl.RestXqTrigger"/>
+    </triggers>
 </collection>


### PR DESCRIPTION
The service import-progress gets reused, because it is not only suited for the import-progress, but any progress. Once fine-tuning is a thing, maybe multiple progress-services might be an option. Or just calling it operation-progress or something like that globally.