### PR TITLE
Concerning Issue #21

### DIFF
--- a/my/XRX/src/core/app/xrx/conf.xqm
+++ b/my/XRX/src/core/app/xrx/conf.xqm
@@ -27,8 +27,8 @@ module namespace conf="http://www.monasterium.net/NS/conf";
 declare namespace xrx="http://www.monasterium.net/NS/xrx";
 declare namespace exist="http://exist.sourceforge.net/NS/exist";
 
-declare variable $conf:project-name := /xrx:conf/xrx:param[@name='project-name']/string();
-declare variable $conf:xrx-live-collection-name := /xrx:conf/xrx:param[@name='xrx-live-collection-name']/string();
+declare variable $conf:project-name := /xrx:conf/xrx:param[@name='project-name'][1]/string();
+declare variable $conf:xrx-live-collection-name := /xrx:conf/xrx:param[@name='xrx-live-collection-name'][1]/string();
 declare variable $conf:db-base-collection-path := concat('/db/', $conf:xrx-live-collection-name, '/', $conf:project-name);
 declare variable $conf:db-base-collection := collection($conf:db-base-collection-path);
 

--- a/my/XRX/src/mom/app/i18n/i18n.app.xml
+++ b/my/XRX/src/mom/app/i18n/i18n.app.xml
@@ -131,7 +131,7 @@ along with VdU/VRET. If not, see http://www.gnu.org/licenses.
 			<xrx:languages>
         <xrx:lang key="ces" old="cz" name="cesky" />
 				<xrx:lang key="deu" old="de" name="deutsch" />
-        <xrx:lang key="est" old="es" name="eesti" />
+        <xrx:lang key="est" old="et" name="eesti" />
 				<xrx:lang key="eng" old="en" name="english" />
         <xrx:lang key="spa" old="es" name="español" />
 				<xrx:lang key="fra" old="fr" name="français" />


### PR DESCRIPTION
Issue #21

Changed Language-Abbreviation for Estonia from "es" to "et".

When multiple Occurence from the project name, just take the first on.

Already tested on dev-mashine 