### PR TITLE
Fix a bug in the imported-fond-widget

### DIFF
--- a/my/XRX/src/mom/app/charters/chimport.xqm
+++ b/my/XRX/src/mom/app/charters/chimport.xqm
@@ -134,13 +134,13 @@ declare function chimport:publish-charters-model(
 declare function chimport:remove-charters-model(
     $request-root as xs:string,
     $xrx-import-xml as element(xrx:import),
-    $imported-collection-cacheid as xs:string) as element() {
+    $imported-charters-cacheid as xs:string) as element() {
 
     <xf:model id="mremove-charters">
     
         <xf:instance>
         	<any_wrapper>
-        		<cacheid>{ $imported-collection-cacheid }</cacheid>
+        		<cacheid>{ $imported-charters-cacheid }</cacheid>
         		<processid>pidremove-charters</processid>
         		{ $xrx-import-xml }
         	</any_wrapper>
@@ -170,7 +170,7 @@ declare function chimport:remove-charters-model(
 declare function chimport:remove-charters-trigger(
     $remove-charters-message as element(xhtml:span),
     $context as xs:string,
-    $imported-collection-cacheid) as element() {
+    $imported-charters-cacheid) as element() {
     
     <xf:group model="mremove-charters">
         <xf:trigger appearance="minimal">
@@ -183,7 +183,7 @@ declare function chimport:remove-charters-trigger(
                 /* Using the import-progress service here, because service-wise it doesn't matter, if the progress is for import or remove. Functionality is the same. */
                 jQuery('#progressbar-remove').progressbarRemove({{
                             serviceUrlRemoveProgress: "{ conf:param('request-root') }service/import-progress",
-                            cacheId: "{ $imported-collection-cacheid }",
+                            cacheId: "{ $imported-charters-cacheid }",
                             processId: "pidremove-charters"
                           }}).progressbar( "value", 0 ).progressbarRemove( "progress" );
               </script>

--- a/my/XRX/src/mom/app/fond/widget/imported-fond.widget.xml
+++ b/my/XRX/src/mom/app/fond/widget/imported-fond.widget.xml
@@ -125,7 +125,7 @@ it leaves the active development stage.
 		return
 		(
 		chimport:publish-charters-model(conf:param('request-root'), $xrx-import-xml),
-		chimport:remove-charters-model(conf:param('request-root'), $xrx-import-xml, $wimported-fond:cacheid, )
+		chimport:remove-charters-model(conf:param('request-root'), $xrx-import-xml, $wimported-fond:cacheid )
 		)
 		}
   </xrx:model>

--- a/my/XRX/src/mom/app/fond/widget/imported-fond.widget.xml
+++ b/my/XRX/src/mom/app/fond/widget/imported-fond.widget.xml
@@ -71,6 +71,16 @@ it leaves the active development stage.
       <xrx:name>$wcharters:metadata-charter-collection</xrx:name>
       <xrx:expression>metadata:base-collection('charter', ($charter:rarchiveid, $charter:rfondid), 'import')</xrx:expression>
     </xrx:variable>
+    <!-- cache info preparation -->
+    <xrx:variable>
+      <xrx:name>$wimported-fond:uri-tokens</xrx:name>
+      <xrx:expression>charters:ruri-tokens()</xrx:expression>
+    </xrx:variable>
+    <!-- cache info -->
+    <xrx:variable>
+      <xrx:name>$wimported-fond:cacheid</xrx:name> <!-- the cacheid should come out as e.g. 'tag:www.monasterium.net,2011:/cache/firstfond/imported-fond' -->
+      <xrx:expression>metadata:atomid('cache', ($wimported-fond:uri-tokens, $xrx:tokenized-uri[last()]))</xrx:expression>
+    </xrx:variable>
     <!-- block-wise navigation -->
     <xrx:variable>
       <xrx:name>$wcharters:preface-exists</xrx:name>
@@ -230,7 +240,8 @@ it leaves the active development stage.
                           <xrx:default>Remove imported charters</xrx:default>
                         </xrx:i18n>
                       </span>,
-                      'fond'
+                      'fond',
+                      $wimported-fond:cacheid
                       )
                       }
                     </div>

--- a/my/XRX/src/mom/app/fond/widget/imported-fond.widget.xml
+++ b/my/XRX/src/mom/app/fond/widget/imported-fond.widget.xml
@@ -125,7 +125,7 @@ it leaves the active development stage.
 		return
 		(
 		chimport:publish-charters-model(conf:param('request-root'), $xrx-import-xml),
-		chimport:remove-charters-model(conf:param('request-root'), $xrx-import-xml)
+		chimport:remove-charters-model(conf:param('request-root'), $xrx-import-xml, $wimported-fond:cacheid, )
 		)
 		}
   </xrx:model>


### PR DESCRIPTION
When previewing imported charters, moderators only recieved an error message. This was due to the fact that a variable was missing from the function call to create the "remove charters widget". This commit should fix this.