### PR TITLE
Issue #176 search2: "Browse in search results" should link to current charter + Issue #217 EditMOM3 "all saved" response occurs even when the document isn't stored in the database

### DIFF
--- a/my/XRX/src/core/app/xrx/js/jquery.xrxInstance.js
+++ b/my/XRX/src/core/app/xrx/js/jquery.xrxInstance.js
@@ -113,14 +113,14 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
 	 * private functions
 	 */
 	function autosave() {
+
 		clearTimeout(onautosave);
 		$("#autoSaveStatus").text("Saving ...");
 		onautosave = setTimeout( function() {
 			// TODO: replace with event handler
-			$(document).xmleditor("save");
+			console.log($(document).xmleditor("save"));
 			$(".xrx-report").xrxReport("validate");
-			$("#autoSaveStatus").text("All changes saved.");
-		}, 1000);
+		}, 1000);	
 	};
 	
 })(jQuery);

--- a/my/XRX/src/mom/app/search/widget/result.widget.xml
+++ b/my/XRX/src/mom/app/search/widget/result.widget.xml
@@ -32,7 +32,21 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
 
 We expect VdU/VRET to be distributed in the future with a license more lenient towards the inclusion of components into other systems, once it leaves the active development stage.
   </xrx:licence>
+    <xrx:constructor>
+    <xrx:parameter>
+      <xrx:name>$constructor:charter</xrx:name>
+      <xrx:default>()</xrx:default>
+    </xrx:parameter>
+    <xrx:parameter>
+      <xrx:name>$constructor:pos</xrx:name>
+      <xrx:default>()</xrx:default>
+    </xrx:parameter>
+    </xrx:constructor>
   <xrx:variables>
+    <xrx:variable>
+     <xrx:name>$wcharter-preview:num</xrx:name>
+     <xrx:expression>$constructor:pos</xrx:expression>
+    </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter-preview:is-loggedin</xrx:name>
       <xrx:expression>xmldb:get-current-user() != 'guest'</xrx:expression>
@@ -169,7 +183,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter-preview:browse-url</xrx:name>
-      <xrx:expression>concat(conf:param('request-root'), $num, '/search-result', '?', request:get-query-string())</xrx:expression>
+      <xrx:expression>concat(conf:param('request-root'), $wcharter-preview:num, '/search-result', '?', request:get-query-string())</xrx:expression>
     </xrx:variable>
   </xrx:variables>
   <xrx:divs>

--- a/my/XRX/src/mom/app/search/widget/search2.widget.xml
+++ b/my/XRX/src/mom/app/search/widget/search2.widget.xml
@@ -636,9 +636,6 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
 		    <div data-demoid="bceb746e-7a77-4337-8e07-4f8b49e7388f" id="dcharter-preview-main">
 			    {
 			    for $charter at $num in session:get-attribute($search:RESULT)[ position() = $wsearch:start to $wsearch:stop ]
-			    let $position :=$num + $wsearch:start -1
-			    let $debug1 := util:log('error', 'in seearhc2')
-			    let $debug2 := util:log('error', $position)
 			    return
 			    <xrx:subwidget>
 			      <xrx:atomid>tag:www.monasterium.net,2011:/mom/widget/result</xrx:atomid>

--- a/my/XRX/src/mom/app/search/widget/search2.widget.xml
+++ b/my/XRX/src/mom/app/search/widget/search2.widget.xml
@@ -636,6 +636,9 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
 		    <div data-demoid="bceb746e-7a77-4337-8e07-4f8b49e7388f" id="dcharter-preview-main">
 			    {
 			    for $charter at $num in session:get-attribute($search:RESULT)[ position() = $wsearch:start to $wsearch:stop ]
+			    let $position :=$num + $wsearch:start -1
+			    let $debug1 := util:log('error', 'in seearhc2')
+			    let $debug2 := util:log('error', $position)
 			    return
 			    <xrx:subwidget>
 			      <xrx:atomid>tag:www.monasterium.net,2011:/mom/widget/result</xrx:atomid>
@@ -646,7 +649,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
 			        </xrx:parameter>
               <xrx:parameter>
                 <xrx:name>$constructor:pos</xrx:name>
-                <xrx:expression>$num</xrx:expression>
+                <xrx:expression>$num + $wsearch:start -1</xrx:expression>
               </xrx:parameter>
 			      </xrx:pass>
 			    </xrx:subwidget>

--- a/my/XRX/src/mom/app/xmleditor/js/jquery.ui.xmleditor.js
+++ b/my/XRX/src/mom/app/xmleditor/js/jquery.ui.xmleditor.js
@@ -28,14 +28,20 @@ $.widget( "ui.xmleditor", {
 	},
 	
 	save: function() {
-		
-		var self = this;
-		console.log( "kuhmuh: " );
+		var self = this;		
 		$.ajax({
 			url: self.options.requestRoot + serviceMyCollectionSave,
 			type: "POST",
 			contentType: "application/xml",
-			data: $(".xrx-instance").text()
+			data: $(".xrx-instance").text(),
+			success: function(){
+				$("#autoSaveStatus").text("All changes saved.");
+				return true;
+			},
+			error: function(){
+			 $("#autoSaveStatus").text("Failed to save changes.");
+			 return false;
+			}			
 		});
 
 	}


### PR DESCRIPTION
Issue: #176: changed in search2.widget.xml
line649: $num to $num + $wsearch:start -1

Added Constructor in result.widget.xml,
Changed in result.widget.xml line 186 $num to $wcharter-preview:num.


Issue #176: 
deleted "all changes saved." text in Jquery.xrxInstance.js;

added in  jquery.ui.xmleditor.js  error --> show text "Failed to save changes"
and added success --> show text "All changes saved."
