### PR TITLE
Changes for Issue #245

### DIFF
--- a/my/XRX/src/mom/app/charter/charter.xqm
+++ b/my/XRX/src/mom/app/charter/charter.xqm
@@ -14,7 +14,7 @@ the Free Software Foundation, either version 3 of the License, or
 VdU/VRET is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+GNU General Public License for more details. 
 
 You should have received a copy of the GNU General Public License
 along with VdU/VRET.  If not, see <http://www.gnu.org/licenses/>.
@@ -183,10 +183,19 @@ declare function charter:charterid($atomid as xs:string, $atom-tag-name as xs:st
 
     let $tokens := charter:object-uri-tokens($atomid, $atom-tag-name)
     return
-    $tokens[last()]
+      xmldb:decode($tokens[last()])
 };
 
+declare function charter:charterid($atomid as xs:string?) as xs:string {
 
+  let $return :=
+    if($atomid != "") then
+      charter:charterid($atomid, conf:param('atom-tag-name'))
+    else
+      ()
+  return
+    $return[1]
+};
 
 declare function charter:permalink($entry as element(atom:entry)) as xs:string {
 
@@ -309,6 +318,7 @@ declare function charter:next-and-previous($charters, $charter, $count as xs:int
         else()
         
     else()
+
 };
 
 declare function charter:position($charters, $charter, $user-xml as element(xrx:user)?, $atom-id as xs:string, $uri-token as xs:string) {
@@ -401,10 +411,17 @@ declare function charter:do-map($idno as xs:string, $mapper, $counter as xs:inte
     returns a sequence of cleaned charter idnos 
     as xs:string which can be used as a URL name
 :)
-declare function charter:map-idnos($idnos as element(cei:idno)+) as xs:string+ {
+declare function charter:map-idnos($idnos as element(cei:idno)+, $isId as xs:boolean?) as xs:string+ {
 
     for $idno in $idnos
-    let $mapped-idno := charter:do-map(string-join($idno/text(), ''), root($charter:translations)/mapper/*, 1)
+    let $mapped-idno :=
+     if( $isId = true() ) then
+      charter:do-map(string-join(data($idno/@id), ''), root($charter:translations)/mapper/*, 1)
+    else
+      charter:do-map(string-join($idno/text(), ''), root($charter:translations)/mapper/*, 1)
+     
+
+      
     return
     if($mapped-idno != '') then $mapped-idno
     else '0000'

--- a/my/XRX/src/mom/app/charter/widget/charter-image-viewer.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/charter-image-viewer.widget.xml
@@ -355,7 +355,12 @@ it leaves the active development stage.
 				else if($wcharter-image-viewer:image-access-forbidden-flag) then
 				<div data-demoid="5d1e4bf8-2698-40e3-aa9d-9f700b629dc0">
           <a href="{ $constructor:link-to-charter-in-archive }" target="_blank">
-            <img src="{ $wcharter-image-viewer:dummy-image-url }" style="position:relative;float:left"/>
+          { 
+            if(not(exists($wcharter-image-viewer:img-urls))) then
+              <img src="{ $wcharter-image-viewer:dummy-image-url }" style="position:relative;float:left"/>
+            else
+              <img src="{ xmldb:decode-uri($wcharter-image-viewer:img-urls[1]) }" style="position:relative;float:left"/>
+          }
           </a>
         </div>
 				else

--- a/my/XRX/src/mom/app/charter/widget/charter.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/charter.widget.xml
@@ -347,7 +347,7 @@ it leaves the active development stage.
       <xrx:name>$wcharter:previous</xrx:name>
       <xrx:expression>
         if($wcharter:context = 'fond' or $wcharter:context = 'collection') then
-          xmldb:encode-uri(concat($wcharter:charter-context-url, $wcharter:next-and-previous[1]//cei:body/cei:idno/@id/string(), '/charter'))
+          xmldb:encode-uri(concat($wcharter:charter-context-url, charter:charterid($wcharter:next-and-previous[1]/root()//atom:id/text()), '/charter'))
         else
           concat('charter?atomid=', $wcharter:next-and-previous[1]/root()//atom:id/text())
       </xrx:expression>
@@ -355,10 +355,13 @@ it leaves the active development stage.
     <xrx:variable>
       <xrx:name>$wcharter:next</xrx:name>
       <xrx:expression>
-        if($wcharter:context = 'fond' or $wcharter:context = 'collection') then
-          xmldb:encode-uri(concat($wcharter:charter-context-url, $wcharter:next-and-previous[2]//cei:body/cei:idno/@id/string(), '/charter'))
-        else
-          concat('charter?atomid=', $wcharter:next-and-previous[2]/root()//atom:id/text())
+       if(exists($wcharter:next-and-previous[2])) then
+            if($wcharter:context = 'fond' or $wcharter:context = 'collection') then
+              xmldb:encode-uri(concat($wcharter:charter-context-url, charter:charterid($wcharter:next-and-previous[2]/root()//atom:id/text()), '/charter'))
+            else
+              concat('charter?atomid=', $wcharter:next-and-previous[2]/root()//atom:id/text())
+       else
+        $wcharter:previous
       </xrx:expression>
     </xrx:variable>
     <!-- 

--- a/my/XRX/src/mom/app/charter/widget/imported-charter.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/imported-charter.widget.xml
@@ -129,7 +129,18 @@ it leaves the active development stage.
      -->
     <xrx:variable>
       <xrx:name>$wcharter:charters</xrx:name>
-      <xrx:expression>charter:get-charter-list($wcharter:metadata-charter-collection, $xrx:tokenized-uri[last()], $xrx:user-xml)</xrx:expression>
+      <xrx:expression>
+      let $wcharter:metadata-charter-collection :=
+        if(empty($wcharter:metadata-charter-collection)) then
+          if($wcharter:context = 'fond') then
+            metadata:base-collection('charter', ($xrx:tokenized-uri[1], $xrx:tokenized-uri[2]), 'import')
+          else
+            metadata:base-collection('charter', $xrx:tokenized-uri[1], 'import')
+        else
+          $wcharter:metadata-charter-collection
+      return
+        charter:get-charter-list($wcharter:metadata-charter-collection, $xrx:tokenized-uri[last()], $xrx:user-xml)
+      </xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter:count</xrx:name>
@@ -223,11 +234,16 @@ it leaves the active development stage.
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter:previous</xrx:name>
-      <xrx:expression>xmldb:encode-uri(concat($wcharter:charter-context-url, $wcharter:next-and-previous[1]//cei:body/cei:idno/@id/string(), '/imported-charter'))</xrx:expression>
+      <xrx:expression>xmldb:encode-uri(concat($wcharter:charter-context-url, charter:charterid($wcharter:next-and-previous[1]/root()//atom:id/text()), '/imported-charter'))</xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter:next</xrx:name>
-      <xrx:expression>xmldb:encode-uri(concat($wcharter:charter-context-url, $wcharter:next-and-previous[2]//cei:body/cei:idno/@id/string(), '/imported-charter'))</xrx:expression>
+      <xrx:expression>
+        if(exists($wcharter:next-and-previous[2])) then
+          xmldb:encode-uri(concat($wcharter:charter-context-url, charter:charterid($wcharter:next-and-previous[2]/root()//atom:id/text()), '/imported-charter'))
+        else
+          $wcharter:previous
+      </xrx:expression>
     </xrx:variable>
     <!-- 
       image tools

--- a/my/XRX/src/mom/app/charter/widget/my-charter.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/my-charter.widget.xml
@@ -228,11 +228,11 @@ it leaves the active development stage.
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter:previous</xrx:name>
-      <xrx:expression>xmldb:encode-uri(concat($wcharter:charter-context-url, $wcharter:next-and-previous[1]//cei:body/cei:idno/@id/string(), '/my-charter'))</xrx:expression>
+      <xrx:expression>xmldb:encode-uri(concat($wcharter:charter-context-url, charter:charterid($wcharter:next-and-previous[1]/root()//atom:id/text()), '/my-charter'))</xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter:next</xrx:name>
-      <xrx:expression>xmldb:encode-uri(concat($wcharter:charter-context-url, $wcharter:next-and-previous[2]//cei:body/cei:idno/@id/string(), '/my-charter'))</xrx:expression>
+      <xrx:expression>xmldb:encode-uri(concat($wcharter:charter-context-url, charter:charterid($wcharter:next-and-previous[2]/root()//atom:id/text()), '/my-charter'))</xrx:expression>
     </xrx:variable>
     <!-- 
         image tools

--- a/my/XRX/src/mom/app/charters/service/excel-import-sheet.service.xml
+++ b/my/XRX/src/mom/app/charters/service/excel-import-sheet.service.xml
@@ -9,7 +9,7 @@
   <xrx:subtitle></xrx:subtitle>
   <xrx:description></xrx:description>
   <xrx:author>jochen.graf@uni-koeln.de</xrx:author>
-  <xrx:licence>
+  <xrx:licence> 
 This is a component file of the VdU Software for a Virtual Research Environment for the handling of Medieval charters.
 
 As the source code is available here, it is somewhere between an alpha- and a beta-release, may be changed without any consideration of backward compatibility of other parts of the system, therefore, without any notice.
@@ -178,7 +178,7 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
     </xrx:progress>
     let $cache := cache:put($cacheid, $processid, $progress2) 
     let $ordered-charter-idnos := charter:ordered-idnos($cei-document)
-    let $cleaned-charter-idnos := charter:map-idnos($ordered-charter-idnos)
+    let $cleaned-charter-idnos := charter:map-idnos($ordered-charter-idnos, false())
     let $unique-charter-idnos := charter:make-unique($cleaned-charter-idnos)
 
     (: import charters :)

--- a/my/XRX/src/mom/app/charters/service/vdu-xml-import.service.xml
+++ b/my/XRX/src/mom/app/charters/service/vdu-xml-import.service.xml
@@ -10,7 +10,7 @@
     <xrx:subtitle/>
     <xrx:description/>
     <xrx:author>jochen.graf@uni-koeln.de</xrx:author>
-    <xrx:licence>
+    <xrx:licence> 
 This is a component file of the VdU Software for a Virtual Research Environment for the handling of Medieval charters.
 
 As the source code is available here, it is somewhere between an alpha- and a beta-release, may be changed without any consideration of backward compatibility of other parts of the system, therefore, without any notice.
@@ -85,7 +85,7 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$cleaned-charter-idnos</xrx:name>
-            <xrx:expression>charter:map-idnos($ordered-charter-idnos)</xrx:expression>
+            <xrx:expression>charter:map-idnos($ordered-charter-idnos, false())</xrx:expression>
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$unique-charter-idnos</xrx:name>

--- a/my/XRX/src/mom/app/charters/service/xml-import.service.xml
+++ b/my/XRX/src/mom/app/charters/service/xml-import.service.xml
@@ -9,7 +9,7 @@
   <xrx:subtitle></xrx:subtitle>
   <xrx:description></xrx:description>
   <xrx:author>jochen.graf@uni-koeln.de</xrx:author>
-  <xrx:licence>
+  <xrx:licence> 
 This is a component file of the VdU Software for a Virtual Research Environment for the handling of Medieval charters.
 
 As the source code is available here, it is somewhere between an alpha- and a beta-release, may be changed without any consideration of backward compatibility of other parts of the system, therefore, without any notice.
@@ -126,11 +126,19 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$cleaned-charter-idnos</xrx:name>
-      <xrx:expression>charter:map-idnos($ordered-charter-idnos)</xrx:expression>
+      <xrx:expression>charter:map-idnos($ordered-charter-idnos, false())</xrx:expression>
+    </xrx:variable>
+    <xrx:variable>
+      <xrx:name>$cleaned-charter-idnos-id</xrx:name>
+      <xrx:expression>charter:map-idnos($ordered-charter-idnos, true())</xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$unique-charter-idnos</xrx:name>
       <xrx:expression>charter:make-unique($cleaned-charter-idnos)</xrx:expression>
+    </xrx:variable>
+    <xrx:variable>
+      <xrx:name>$unique-charter-idnos-id</xrx:name>
+      <xrx:expression>charter:make-unique($cleaned-charter-idnos-id)</xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$count-charters</xrx:name>
@@ -181,11 +189,29 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
        
       (: make the unique idno part of the cei document :)
       let $unique-idno := $unique-charter-idnos[$pos]
+      let $unique-idno-id :=
+       if( exists($idno/@id) ) then
+        $unique-charter-idnos-id[$pos]
+       else
+        ""
+        
+
+      (: atom info: Build from @id if available :)
+      let $atomid := 
+        if($unique-idno-id != "") then
+          metadata:atomid('charter', ($uri-tokens, $unique-idno-id))
+        else
+          metadata:atomid('charter', ($uri-tokens, $unique-idno))
+      
+      (: FileName: Build from @id if available :) 
+      let $entry-name :=  
+        if($unique-idno-id != "") then
+          xmldb:encode(concat($unique-idno-id, '.cei.xml'))
+        else
+          xmldb:encode(concat($unique-idno, '.cei.xml'))
+
       let $insert-unique-idno := charter:insert-unique-idno($charter, $unique-idno)
-       
-      (: atom info :)
-      let $atomid := metadata:atomid('charter', ($uri-tokens, $unique-idno))
-      let $entry-name := xmldb:encode(concat($unique-idno, '.cei.xml'))
+
        
       let $charter-entry :=
       <atom:entry xmlns:atom="http://www.w3.org/2005/Atom">

--- a/my/XRX/src/mom/app/charters/sqlimport.xqm
+++ b/my/XRX/src/mom/app/charters/sqlimport.xqm
@@ -89,7 +89,7 @@ declare function sqlimport:do($driverclass,
         let $break := if(not($is-valid) or $execute/@count/string() = '0') then xs:string(break) else()
         
         (: charter info :)
-        let $idno := charter:map-idnos($data-transformed//cei:body/cei:idno)
+        let $idno := charter:map-idnos($data-transformed//cei:body/cei:idno, false())
         let $atomid := metadata:atomid('charter', ($uri-tokens, $idno))
         let $entry-name := xmldb:encode(concat($idno, '.cei.xml'))
         let $charter-entry := 

--- a/my/XRX/src/mom/app/collection/service/my-collection-bookmarks.service.xml
+++ b/my/XRX/src/mom/app/collection/service/my-collection-bookmarks.service.xml
@@ -53,7 +53,7 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
 		        let $uri-tokens := metadata:uri-tokens($atomid)
 		        let $base-collection := metadata:base-collection('charter', $uri-tokens, 'public')
 		        let $entry := $base-collection//atom:id[.=$atomid]/parent::atom:entry
-		        let $idno := $entry//cei:body/cei:idno/@id/string()
+		        let $idno := charter:charterid($atomid)
 		        let $title := string-join(($uri-tokens, $idno), ' | ')
 		        let $objectid := metadata:objectid($atomid)
 		        let $link := concat(conf:param('request-root'), string-join($uri-tokens, '/'), '/', $objectid, '/charter')

--- a/my/XRX/src/mom/app/collection/widget/charter-preview-importedcollection.widget.xml
+++ b/my/XRX/src/mom/app/collection/widget/charter-preview-importedcollection.widget.xml
@@ -55,7 +55,7 @@ it leaves the active development stage.
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter-preview:id</xrx:name>
-      <xrx:expression>data($wcharter-preview:idno-element/@id)</xrx:expression>
+      <xrx:expression>charter:charterid($wcharter-preview:atom-id)</xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter-preview:date</xrx:name>

--- a/my/XRX/src/mom/app/crop/widget/image-tools.widget.xml
+++ b/my/XRX/src/mom/app/crop/widget/image-tools.widget.xml
@@ -588,13 +588,28 @@ div.no-graphic{{
     </xrx:model>
     <xrx:view>
 	  {
-	    (: metadata base collection for archival collections :)
-	    let $metadata-collection-base-collection := metadata:base-collection('collection', 'public')
-
+	    (: metadata base collection for archival collections 
+	    ~ Tokenize the first Token to check if it is a collection or a "MyCollection"
+	    ~ If it has 5 Segments, it is a "MyCollection" otherwise "Collection" :)
+	    
+	    let $col-token := tokenize($xrx:tokenized-uri[1], "-")
+	    
+	    (: Decide which Collection is to choose :)
+	    let $metadata-collection-base-collection :=
+	     if(count($col-token) = 5 ) then
+	      metadata:base-collection('mycollection', 'public')
+	     else
+	      metadata:base-collection('collection', 'public')
+	      
       (: get charter context: collection or fond? :)
       let $charter-context := 
         let $probably-collection-id := $xrx:tokenized-uri[1]
-        let $probably-collection-atom-id := concat(conf:param('atom-tag-name'), '/collection/', $probably-collection-id)
+        let $probably-collection-atom-id := 
+          if(count($col-token) = 5) then
+            concat(conf:param('atom-tag-name'), '/mycollection/', $probably-collection-id)
+          else 
+            concat(conf:param('atom-tag-name'), '/collection/', $probably-collection-id)
+            
         return
         if(exists($metadata-collection-base-collection//atom:id[.=$probably-collection-atom-id])) then 'collection' else 'fond'
 
@@ -623,7 +638,8 @@ div.no-graphic{{
       (:
         getting the CEI document from public area of MOM-CA
       :)
-      
+
+           
       (:
          now we know which charter we want
       :)
@@ -635,10 +651,12 @@ div.no-graphic{{
       let $idno := $charter//cei:body/cei:idno/text()
       let $link-to-charter-in-archive := data($charter//cei:archIdentifier/cei:ref/@target)
 
-      (:
+
+       (:
         get number of charters in a collection or
         number of saved or released charters
       :)
+      
       let $charters := charter:get-charter-list($metadata-charter-collection, xs:string('charter'), $xrx:user-xml)
 
       (: count charters :)
@@ -694,7 +712,7 @@ div.no-graphic{{
             return
                 if(contains($url, '/')) then $url
                 else concat($image-base-uri, xmldb:encode($url))
-
+ 
 	    return
       <div data-demoid="e83f0d58-244b-47d2-a23b-979421e2a101" id="charter-template-header">
         {
@@ -704,11 +722,14 @@ div.no-graphic{{
           else
             concat(conf:param('request-root'),xmldb:decode($charter:rcollectionid),'/')
         let $self-charter := 
-          xmldb:encode-uri(concat($charter-context-url,$charter//cei:body/cei:idno/@id/string(),'/charter'))
+          xmldb:encode-uri(concat($charter-context-url,charter:charterid($atom-id),'/charter'))
         let $previous := 
-          xmldb:encode-uri(concat($charter-context-url,$next-and-previous[1]//cei:body/cei:idno/@id/string(),'/image-tools'))
+          xmldb:encode-uri(concat($charter-context-url,charter:charterid($next-and-previous[1]/../../atom:id/text()),'/image-tools'))
         let $next := 
-          xmldb:encode-uri(concat($charter-context-url,$next-and-previous[2]//cei:body/cei:idno/@id/string(),'/image-tools'))
+          if(not(empty($next-and-previous[2]))) then
+            xmldb:encode-uri(concat($charter-context-url,charter:charterid($next-and-previous[2]/../../atom:id/text()),'/image-tools'))
+          else
+            $previous
         return
         
         (: 

--- a/my/XRX/src/mom/app/fond/widget/charter-preview-importedfond.widget.xml
+++ b/my/XRX/src/mom/app/fond/widget/charter-preview-importedfond.widget.xml
@@ -55,7 +55,7 @@ it leaves the active development stage.
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter-preview:id</xrx:name>
-      <xrx:expression>data($wcharter-preview:idno-element/@id)</xrx:expression>
+      <xrx:expression>charter:charterid($wcharter-preview:atom-id)</xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter-preview:date</xrx:name>

--- a/my/XRX/src/mom/app/mom/service/charter-pdf.service.xml
+++ b/my/XRX/src/mom/app/mom/service/charter-pdf.service.xml
@@ -54,7 +54,7 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
 	       metadata:base-collection('charter', $collection-id, 'public')
 	  (: select the charter file :)     
 	  let $charter := $public-base-collection//atom:id[.=$charter-atomid]/parent::atom:entry/atom:content/cei:text
-	  let $charter-id := xmldb:encode($charter//cei:idno/@id)
+	  let $charter-id := xmldb:encode(charter:charterid($charter-atomid))
 	  
 	  (: load the xslt- script and define the parameters :)
 	  let $xsl := $xrx:db-base-collection/xsl:stylesheet[@id='charter2pdf']
@@ -106,5 +106,5 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
 	  return
 	  $charter-as-pdf
 	  }
-	</xrx:body>
+	  </xrx:body> 
 </xrx:service>

--- a/my/XRX/src/mom/app/mom/service/notes-as-pdf.service.xml
+++ b/my/XRX/src/mom/app/mom/service/notes-as-pdf.service.xml
@@ -81,7 +81,7 @@
 
       (: select the charter file :)
       let $charter := $public-base-collection//atom:id[.=$note-atom-id]/parent::atom:entry/atom:content/cei:text
-      let $charter-id := xmldb:encode($charter//cei:idno/@id)
+      let $charter-id := xmldb:encode(charter:charterid($note-atom-id))
       return
       <xrx:bookmark-note>
         <xrx:note>{ $note//xrx:note/text() }</xrx:note>

--- a/my/XRX/src/mom/app/mom/widget/charter-preview.widget.xml
+++ b/my/XRX/src/mom/app/mom/widget/charter-preview.widget.xml
@@ -68,7 +68,7 @@ it leaves the active development stage.
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter-preview:id</xrx:name>
-      <xrx:expression>data($wcharter-preview:idno-element/@id)</xrx:expression>
+      <xrx:expression>charter:charterid($wcharter-preview:atom-id)</xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter-preview:date</xrx:name>
@@ -88,7 +88,7 @@ it leaves the active development stage.
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter-preview:charter-url</xrx:name>
-      <xrx:expression>concat(conf:param('request-root'), $charter:rarchiveid, '/', $charter:rfondid, '/', xmldb:encode($wcharter-preview:id), '/charter')</xrx:expression>
+      <xrx:expression>concat(conf:param('request-root'), $charter:rarchiveid, '/', $charter:rfondid, '/', xmldb:encode(charter:charterid(root($constructor:charter)//atom:id/text())) , '/charter')</xrx:expression>
     </xrx:variable>
   <!-- status of the charter -->
     <xrx:variable>

--- a/my/XRX/src/mom/app/search/widget/result.widget.xml
+++ b/my/XRX/src/mom/app/search/widget/result.widget.xml
@@ -120,7 +120,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter-preview:id</xrx:name>
-      <xrx:expression>data($wcharter-preview:idno-element/@id)</xrx:expression>
+      <xrx:expression>charter:charterid($wcharter-preview:atom-id)</xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter-preview:abstract</xrx:name>


### PR DESCRIPTION
A lot of Changes for Issue #245 
Togehter with #266 . #274 and some Bug-Fixing

-- When just 1 Charter was imported inside a Fond/Collection, Function next-and-previous fails. Check for additional Charters was fixed. If there isn't another charter, wcharter:next gets a reference to wcharter:previous (itself) 