### PR TITLE
Issue: #217 EditMOM3 "all saved" response occurs even when the document isn't stored in the database

### DIFF
--- a/my/XRX/src/mom/app/collection/service/my-collection-save.service.xml
+++ b/my/XRX/src/mom/app/collection/service/my-collection-save.service.xml
@@ -50,6 +50,30 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
       <xrx:name>$feed</xrx:name>
       <xrx:expression>substring-after($base-collection-path, conf:param('atom-db-base-uri'))</xrx:expression>
     </xrx:variable>
+    <xrx:variable>
+      <xrx:name>$data-content</xrx:name>
+      <xrx:expression>$data//atom:content/descendant-or-self::*</xrx:expression>
+    </xrx:variable>
+    <xrx:variable>
+      <xrx:name>$data-content-debug</xrx:name>
+      <xrx:expression>util:log('error', $data-content)</xrx:expression>
+    </xrx:variable>
+    <xrx:variable>
+     <xrx:name>$data_hash</xrx:name>
+     <xrx:expression>util:hash(util:serialize($data-content, ()), 'md5')</xrx:expression>
+    </xrx:variable>
+    <xrx:variable>
+     <xrx:name>$data_hash_debug</xrx:name>
+     <xrx:expression>util:log('error',$data_hash)</xrx:expression>
+    </xrx:variable>
+    <xrx:variable>
+     <xrx:name>$doc-path</xrx:name>
+     <xrx:expression>concat("/db/mom-data",$feed,"/", $entry-name)</xrx:expression>
+    </xrx:variable>
+    <xrx:variable>
+      <xrx:name>$doc-path-debug</xrx:name>
+      <xrx:expression>util:log('error', $doc-path)</xrx:expression>
+    </xrx:variable>
   </xrx:variables>
   <xrx:init>
    <xrx:processor>
@@ -58,9 +82,17 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
   </xrx:init>
   <xrx:body>
     {
+      (: write changes in db :)
       let $put := atom:PUT($feed, $entry-name, $data)
-      return
-      $data
+      
+      let $saved-data-content := doc($doc-path)//atom:content/descendant-or-self::*
+      let $saved-data-content-hash := util:hash(util:serialize($saved-data-content, ()),'md5')  
+ 
+      let $compared := compare($saved-data-content-hash, $data_hash)
+
+      return if ($compared = 0) then <result>true</result>
+              else <result>false</result>
+     
     }
   </xrx:body>
 </xrx:service>

--- a/my/XRX/src/mom/app/collection/service/my-collection-save.service.xml
+++ b/my/XRX/src/mom/app/collection/service/my-collection-save.service.xml
@@ -54,25 +54,13 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
       <xrx:name>$data-content</xrx:name>
       <xrx:expression>$data//atom:content/descendant-or-self::*</xrx:expression>
     </xrx:variable>
-    <xrx:variable>
-      <xrx:name>$data-content-debug</xrx:name>
-      <xrx:expression>util:log('error', $data-content)</xrx:expression>
-    </xrx:variable>
-    <xrx:variable>
+     <xrx:variable>
      <xrx:name>$data_hash</xrx:name>
      <xrx:expression>util:hash(util:serialize($data-content, ()), 'md5')</xrx:expression>
     </xrx:variable>
     <xrx:variable>
-     <xrx:name>$data_hash_debug</xrx:name>
-     <xrx:expression>util:log('error',$data_hash)</xrx:expression>
-    </xrx:variable>
-    <xrx:variable>
      <xrx:name>$doc-path</xrx:name>
      <xrx:expression>concat("/db/mom-data",$feed,"/", $entry-name)</xrx:expression>
-    </xrx:variable>
-    <xrx:variable>
-      <xrx:name>$doc-path-debug</xrx:name>
-      <xrx:expression>util:log('error', $doc-path)</xrx:expression>
     </xrx:variable>
   </xrx:variables>
   <xrx:init>
@@ -85,11 +73,13 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
       (: write changes in db :)
       let $put := atom:PUT($feed, $entry-name, $data)
       
+      (: get saved atom:content and childs from the saved document and create hash-value:)
       let $saved-data-content := doc($doc-path)//atom:content/descendant-or-self::*
       let $saved-data-content-hash := util:hash(util:serialize($saved-data-content, ()),'md5')  
  
+      (: compare hash-values of from the saved document and the control data.:) 
       let $compared := compare($saved-data-content-hash, $data_hash)
-
+ 
       return if ($compared = 0) then <result>true</result>
               else <result>false</result>
      

--- a/my/XRX/src/mom/app/xmleditor/js/jquery.ui.xmleditor.js
+++ b/my/XRX/src/mom/app/xmleditor/js/jquery.ui.xmleditor.js
@@ -26,7 +26,7 @@ $.widget( "ui.xmleditor", {
         });
 		$("#ui-imageann").imageann();
 	},
-	
+	/* ajax-request of my-collection-save.service.xml */
 	save: function() {
 		var self = this;		
 		$.ajax({
@@ -34,12 +34,26 @@ $.widget( "ui.xmleditor", {
 			type: "POST",
 			contentType: "application/xml",
 			data: $(".xrx-instance").text(),
-			success: function(){
-				$("#autoSaveStatus").text("All changes saved.");
-				return true;
+			dataType: "xml",
+			  /* 
+			   * success function
+			   * save-script was loaded, 
+			   * if result = true the save-function is completed and the save function was a success
+			   * if result = false the save-function is completed but the save function was not a success
+			   */	
+			success: function(response){
+				if($(response).find('result').text() == "true"){
+					$("#autoSaveStatus").text("All changes saved.");
+					return true;
+				}
+				else {
+					$("#autoSaveStatus").text("Failed to save changes.");
+					return false;
+				}			
 			},
 			error: function(){
-			 $("#autoSaveStatus").text("Failed to save changes.");
+			 $("#autoSaveStatus").text("Error: Failed to load save-script.");
+			 
 			 return false;
 			}			
 		});


### PR DESCRIPTION
In my-collection-save.service.xml: 
 added methods to create hash-values from the data to be saved, and from the saved date.
Then compare the two hash-values. When the values are same, then return true, when not return false.

In jquery.ui.xmleditor.js:
Get the return value from my-collection-save.service.xml, when true write message: "All changes saved."
When false write message "Failed to save changes." 
When jquery.ui.xmleditor.js can't load the save-script write the message: "Error: Failed to load save-script."

