### PR TITLE
Fix for issue 417. implemented a check for existing item in array

### DIFF
--- a/my/XRX/src/mom/app/charter/widget/my-charter.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/my-charter.widget.xml
@@ -231,8 +231,12 @@ it leaves the active development stage.
       <xrx:expression>xmldb:encode-uri(concat($wcharter:charter-context-url, charter:charterid($wcharter:next-and-previous[1]/root()//atom:id/text()), '/my-charter'))</xrx:expression>
     </xrx:variable>
     <xrx:variable>
+      <xrx:name>$wcharter:next-char</xrx:name>
+      <xrx:expression>if(exists($wcharter:next-and-previous[2]))then $wcharter:next-and-previous[2] else $wcharter:next-and-previous[1]</xrx:expression>
+    </xrx:variable>
+    <xrx:variable>
       <xrx:name>$wcharter:next</xrx:name>
-      <xrx:expression>xmldb:encode-uri(concat($wcharter:charter-context-url, charter:charterid($wcharter:next-and-previous[2]/root()//atom:id/text()), '/my-charter'))</xrx:expression>
+      <xrx:expression>xmldb:encode-uri(concat($wcharter:charter-context-url, charter:charterid($wcharter:next-char/root()//atom:id/text()), '/my-charter'))</xrx:expression>
     </xrx:variable>
     <!-- 
         image tools


### PR DESCRIPTION
#417 

Error in my-charter.widget.xml was fixed.
It only occurs if there were just one charter in a collection.

Test:
Add a new private collection.
Create just one blank charter and open it.