### PR TITLE
Issue #451 bookmark of some charters leads to error in bookmarks overview

### DIFF
--- a/my/XRX/src/mom/app/bookmark/widget/bookmarks.widget.xml
+++ b/my/XRX/src/mom/app/bookmark/widget/bookmarks.widget.xml
@@ -131,20 +131,22 @@
 					let $all-user-xmls := $user:db-base-collection/xrx:user
 					for $bookmarked-charter at $num in $wbookmarks:bookmarked-charters[position() = $wbookmarks:startstop]
 					return
+					
 					(: get charter context: collection or fond? :)
 					let $tokens := tokenize(substring-after($bookmarked-charter, conf:param('atom-tag-name')), '/')
-					
 					let $charter-context := 
-					let $probably-collection-id := $tokens[3]
-					let $probably-collection-atom-id := metadata:atomid('collection', $probably-collection-id)
-					return
-					if(exists(metadata:base-collection('collection', 'public')//atom:id[.=$probably-collection-atom-id])) then 'collection' else 'fond'
+					let $probably-collection-id := $tokens[3]			
+					let $collection-id-tokens-count := count(tokenize($probably-collection-id, '-'))
+					let $collection-context := 				  
+					    if($collection-id-tokens-count=5) then 'mycollection' else 'collection'
+					let $probably-collection-atom-id := metadata:atomid($collection-context, $probably-collection-id)
+					return				 
+					 if(exists(metadata:base-collection($collection-context, 'public')//atom:id[.=$probably-collection-atom-id])) then 'collection' else 'fond'
 					
 					let $charter-id := $tokens[last()]
 					let $fond-id := if($charter-context = 'fond') then $tokens[last() - 1] else 'null'
 					let $archive-id := if($charter-context = 'fond') then $tokens[last() - 2] else 'null'
 					let $collection-id := if($charter-context = 'collection') then $tokens[last() - 1] else 'null'
-					
 					(: init metadata database collection :)        
 					let $metadata-charter-collection := 
 					if($charter-context = 'fond') then
@@ -152,7 +154,7 @@
 					else
 					metadata:base-collection('charter', $collection-id, 'public')
 					
-					(: get charter :)
+					(: get charter :)					
 					let $charter := root($metadata-charter-collection//atom:id[.=$bookmarked-charter])//cei:text
 					return
 					<div data-demoid="b5f5092c-ccb0-4b73-93af-f70df8d6040b" id="ch{ $num }">


### PR DESCRIPTION
Fast sulution: 
Created the new Variable $collection-context with the values 'collection' or 'mycollection'.
bookmarks.widget.xml tests if the bookmark a bookmark to a published charter by a User or a collection from a fond. 

Long-Term Solution: See StephanMa post at issue #451 
