### PR TITLE
Issue #482 List of charters in moderator enivornment suggested for publication should include date of release by user

### DIFF
--- a/my/XRX/src/mom/app/publication/service/release-charter.service.xml
+++ b/my/XRX/src/mom/app/publication/service/release-charter.service.xml
@@ -79,6 +79,10 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
       <xrx:expression>upd:replace-element-content($charter-to-release, text { 'yes' })</xrx:expression>
     </xrx:variable>
     <xrx:variable>
+        <xrx:name>$updated-released</xrx:name>
+        <xrx:expression>upd:insert-after($updated//xrx:saved[xrx:id=$atomid]/xrx:freigabe, <xrx:released>{current-dateTime()}</xrx:released>)</xrx:expression>
+    </xrx:variable>
+    <xrx:variable>
       <xrx:name>$user-xml</xrx:name>
       <xrx:expression>$user:db-base-collection/xrx:user[.//xrx:saved/xrx:id=$atomid]</xrx:expression>
     </xrx:variable>
@@ -122,7 +126,7 @@ MOM-CA with the following role: moderator
   <xrx:body>
 		{
 		let $store := 
-		 if($charter-to-release) then atom:PUT(conf:param('xrx-user-atom-base-uri'), concat(xmldb:encode($xrx:user-id), '.xml'), $updated)
+		 if($charter-to-release) then atom:PUT(conf:param('xrx-user-atom-base-uri'), concat(xmldb:encode($xrx:user-id), '.xml'), $updated-released)
 		 else()
     let $sendmail :=
     <xrx:sendmail>

--- a/my/XRX/src/mom/app/publication/widget/charters-to-publish.widget.xml
+++ b/my/XRX/src/mom/app/publication/widget/charters-to-publish.widget.xml
@@ -200,11 +200,11 @@ right:220px;
 	      
 	      
 	      for $id-element at $num in $charters-to-publish
-	
-	      
+		  let $releasedate-time := root($id-element)//xrx:saved[xrx:id=$id-element]/xrx:released
+		  let $releaseddate := tokenize($releasedate-time,'T')[1]
 	      let $atom-id := $id-element/text()
 	      let $email := root($id-element)//xrx:email/text()
-	      
+	      	      
 	      (: initialize metadata collections :)
 	      let $tokens := tokenize(substring-after($atom-id, conf:param('atom-tag-name')), '/')
 	
@@ -302,6 +302,13 @@ right:220px;
 	              <xrx:default>Edited by</xrx:default>
 	            </xrx:i18n>
 	            <span>: { user:firstname-name($email) }</span>
+	          </div>
+	          <div>
+	          	<xrx:i18n>
+	          		<xrx:key>released-at</xrx:key>
+	          		<xrx:default>Released</xrx:default>
+	          	</xrx:i18n>
+	          	<span>: {$releaseddate}</span>
 	          </div>
 	          <br/>
 		      </div>


### PR DESCRIPTION
- when a user release a charter, the new Element xrx:released with the current date will be created in the user.xml
- In the charters to release view is a new field released with the date.
