### PR TITLE
Fix problem with search result ordering

### DIFF
--- a/my/XRX/src/mom/app/search/search.xqm
+++ b/my/XRX/src/mom/app/search/search.xqm
@@ -218,7 +218,7 @@ declare function search:anno-query-string() {
 declare function search:sort-query-string() {
 
     if($search:sort = 'date') then
-    ' order by (number($charter//cei:date/@value), number($charter//cei:dateRange/@from), number($charter//cei:dateRange/@to))[1] ascending '
+    ' order by (number($charter//cei:issued/cei:date[1]/@value), number($charter//cei:issued/cei:dateRange[1]/@from), number($charter//cei:issued/cei:dateRange[1]/@to))[1] ascending '
     else
     ' order by ft:score($charter) descending '    
 };


### PR DESCRIPTION
When a charter to be included in the search result charter has more than one `cei:date`/`cei:dateRange` element, an error was thrown. This pull request changes the sorting code to only take the first `cei:text//cei:issued/cei:date` or `cei:text//cei:issued/cei:dateRange` element into account for sorting.
Tested on the dev server.