### PR TITLE
Bug 579

### DIFF
--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -682,9 +682,6 @@
             <xsl:apply-templates/>
         </xsl:element>
     </xsl:template>
-    <xsl:template match="cei:ref[@type = 'bibliography']">
-        <xsl:apply-templates/>
-    </xsl:template>
     <xsl:template match="cei:persName">
     <xsl:variable name="i18n">
         <xrx:i18n>


### PR DESCRIPTION
after cleaning up data the workaround for SSRQ_AR_AI_1_Nr_1 (template for `cei:ref[@type=bibliography]) is not necessary anymore. Solves #579.