### PR TITLE
make `@resp` generic

### DIFF
--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -5425,10 +5425,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">
-          Der verantwortliche Bearbeiter für die normalisierten Angaben und die
-          Angaben zum Befund.
-              </xs:documentation>
+                <xs:documentation xml:lang="deu">Der verantwortliche Bearbeiter für die
+                    Kodierung, den Inhalt der Kodierung oder die vergebenen Attribute.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5656,6 +5654,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
         <xs:attributeGroup ref="id"/>
         <xs:attributeGroup ref="n"/>
         <xs:attributeGroup ref="facs"/>
+        <xs:attributeGroup ref="resp"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="facs">
         <xs:attribute name="facs">

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -5191,8 +5191,8 @@
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu"> Der verantwortliche Bearbeiter für die
-                    normalisierten Angaben und die Angaben zum Befund. </xs:documentation>
+                <xs:documentation xml:lang="deu">Der verantwortliche Bearbeiter für die
+                    Kodierung, den Inhalt der Kodierung oder die vergebenen Attribute.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5382,6 +5382,7 @@
         <xs:attributeGroup ref="id"/>
         <xs:attributeGroup ref="n"/>
         <xs:attributeGroup ref="facs"/>
+        <xs:attributeGroup ref="resp"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="facs">
         <xs:attribute name="facs">


### PR DESCRIPTION
... as result of a conference I attended, I learned that accepting MOM as a tool even for small changes by the scholars can be made easier if the schema allows for assigning responsibility to any taxt fragment which can be identified by a tag, so I added the `@resp` to the `standard` attribute group