### PR TITLE
debug for Issue750

### DIFF
--- a/my/XRX/src/mom/app/collection/mycharters.xqm
+++ b/my/XRX/src/mom/app/collection/mycharters.xqm
@@ -36,13 +36,13 @@ import module namespace charters="http://www.monasterium.net/NS/charters"
   charter view
 :)
 declare function mycharters:entries($charter-base-collection) {
-
     for $entry in $charter-base-collection/atom:entry
     let $just-linked-atomid := $entry/atom:content/@src/string()
     let $cei-text := 
         if($just-linked-atomid != '') then charter:public-entry($just-linked-atomid)
         else $entry
-    let $date := $cei-text//cei:issued/(cei:date/@value|cei:dateRange/@from)
+    let $date := if(exists($cei-text//cei:issued/cei:date/@value)) then $cei-text//cei:issued/cei:date/@value
+    else $cei-text//cei:issued/cei:dateRange/@from
     order by xs:integer($date)
     return
     $entry

--- a/my/XRX/src/mom/app/collection/service/my-collection-items.service.xml
+++ b/my/XRX/src/mom/app/collection/service/my-collection-items.service.xml
@@ -55,10 +55,9 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
         if(count($entries) gt 0) then
           jsonx:object(
             for $entry at $num in $entries
-            
+            let $entrydebug := util:log("ERROR", $entry)
            
             let $objectid := metadata:objectid($entry//atom:id/text())
-            let $debug1 := util:log("ERROR", $objectid)
             
             (: These is part of the function publication:build-url
             ~ function is not callable from service :)
@@ -70,8 +69,7 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
             let $collectionid := $sub[1]
             let $url := if($context = "collection") then concat($collectionid, "/", $objectid) else concat($archiveid, "/", $fondid, "/", $objectid)
               
-            let $date := if(exists($entry//cei:dateRange/@from/string())) then $entry//cei:dateRange/@from/string() else $entry//cei:date/@value/string()
-            let $debug2 := util:log("ERROR", $date)
+            let $date := if(exists($entry//cei:date/@value/string())) then $entry//cei:date/@value/string() else $entry//cei:dateRange/@from/string()
             
             let $idno := $entry//cei:body/cei:idno/text()
             let $title := 

--- a/my/XRX/src/mom/app/collection/service/my-collection-items.service.xml
+++ b/my/XRX/src/mom/app/collection/service/my-collection-items.service.xml
@@ -54,11 +54,8 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
       let $json := 
         if(count($entries) gt 0) then
           jsonx:object(
-            for $entry at $num in $entries
-            let $entrydebug := util:log("ERROR", $entry)
-           
+            for $entry at $num in $entries       
             let $objectid := metadata:objectid($entry//atom:id/text())
-            
             (: These is part of the function publication:build-url
             ~ function is not callable from service :)
             let $token := tokenize($entry/atom:id/text(), "/")


### PR DESCRIPTION
Some charters have dateRange/@from and date/@value.
mycharters:entries and my-collection-items.service.xml now checks if date/@value exists and prefers this before dateRange/@from