### PR TITLE
solving issue #780

### DIFF
--- a/my/XRX/src/mom/app/charter/js/charter.js
+++ b/my/XRX/src/mom/app/charter/js/charter.js
@@ -207,52 +207,60 @@ else 	{
 
 }
 
-/*function rapper is uses to show the clicked glossary entry in a viewport on the single charter view. */
+/* ********
+ *  * function addinfo gives additional info to index terms in the single charter view. Till now there are 2 collections, 
+ *  where controlled vocabularies can be saved and retrieved in the data base:
+ *  metadata.person.public and metadata.controlledVocabularies.public.
+ *  In metadata.controlledVocabularies.public files are in skos and in different languages.
+ *  The files in metadata.person.public are TEIs. Until now there are 2 kinds of structures: a low structured
+ *  one containing a unique key, a persName, occupation of the person and maybe a comment on the person.
+ *  The other one BischoefeAblaesse is deeper nested,that is why there is a special handling (1.if-clause) for that case.  
+ *  The additional information is retrieved from the service "getTextfromGlossar" via ajax. 
+ *  The data from the service is prepared and integrated in the single charter view.
+ *  The function is called in charter and my-charter.widget.
+ *   */
 
-function rapper(){		
-	
-		var infoeintrag = $('li[value="true"]');		
+function addInfo(){		
+		
+		var findlang = $("select[name='_lang']").children("option[selected='selected']");
+		/* lang in voc has 2 chars not 3*/	
+		console.log($(findlang));
+		var lang = $(findlang)[0].value.substring(0,2) || 'eng';	
+		
 		/* normally all li where value = true (which means that there is more information provided to this index)
-		 * has an eception which is the illurk-vocabulary and vis, because until now there is no additional info.
+		 * has an eception which is the vis, because until now there is no additional info.
 		 * 
 		 * */
-		$('li[value="true"]:not(.illurk-vocabulary):not(.vis)').each(function(){
-	
-			var glossartyp= $(this)[0].className;
+		$('li[value="true"]:not(.vis)').each(function(){
+			var self = this,
+			vocabulary = self.className,
+			term = self.attributes.lemma || self.attributes.id;
 			
-				if ($(this)[0].attributes.lemma == undefined)
-					{
-					var entry = $(this)[0].attributes.id.value;
-					}
-				else{
-					var entry = $(this)[0].attributes.lemma.value;
-				}
-				
-				var gentry = entry.charAt(0).toUpperCase() + entry.slice(1);				
+			var begriff = term.value; 
+			
+			var category = (self.attributes.lemma == undefined)? 'person': 'item';		
+							
 				var anker = $('<a><a>').addClass('eintrag');
 				$(this).append('<span class="info_i">i</span>');
 				$(this).wrapInner(anker);				
 							
-				$(this).click( function(){
-					console.log("click event on list");					
-					$("div#enhancedView").empty();
-										
-			        console.log(glossartyp);
+				$(this).click( function(){					
+					
+					$("div#enhancedView").empty();			
 			        $.ajax({     
 			        	url: "/mom/service/getTextfromGlossar",
 			        	type:"GET",      
 			        	contentType: "application/xml",     
 			        	dataType: "xml",
-			        	data: { id : gentry, typ : glossartyp},
+			        	data: { id : begriff, typ : vocabulary, cat: category},
 			        	success: function(data, textStatus, jqXHR)
 			        	{    
-			        		if (glossartyp == 'bishop' ){
+			        		
+			        		if (vocabulary == 'BischoefeAblaesse' ){
 			        			var note = $(data).find("tei\\:note");
-			        			console.log("Note NOte");
-			        			console.log(note);
-			        			console.log($(data));
+			        			
 			        			var person = $(data).text();			        			
-			        			/* Person data is retrieved as text
+			        			/* Person data of BischoefeAblaesse is retrieved as text
 			        			 * Problem of textformatting: 
 				        		 * in order to be able to insert whitespaces again
 				        		 * this is done via regex. 
@@ -270,12 +278,24 @@ function rapper(){
 			        			$("div#enhancedView").append(port);				        			
 			        	
 			        		}
-			        		else {				        		
-
-			        			var preflabel = $(data).find("skos\\:prefLabel");
+			        		else if((category == 'person') && (vocabulary != 'BischoefeAblaesse')){
+			        			/* the person data is retrieved from TEI-files in metadata.person.public.
+			        			 * These person lists are low structured: persName, occupation, maybe note. */
+			        			var name = $(data).find("tei\\:persName").text();
+			        			var h = $("<h3></h3>").append(name);			        			
+			        			//var more = $(data).children("div.port").children().not(name)
+			        			var occupation = $(data).find("tei\\:occupation").text();
+			        			var p = $("<p></p>").append(occupation);
+			        			var note = $("<p></p>").append($(data).find("tei\\:note").text());
+			        		
+			        			var port = $("<div class='port'></div>").append(h).append(p).append(note);
+			        			$("div#enhancedView").append(port);			        			
+			        		}
+			        		else {	
+			        			var preflabel = $(data).find("skos\\:prefLabel[xml\\:lang='" + lang +"']");			        			
 			        			var h = $("<h3></h3>").append(preflabel);			        			
-			        				var def = $(data).find("skos\\:definition");
-			        			var div = $("<div class='bla'></div>").append(def);
+			        			var def = $(data).find("skos\\:definition");
+			        			var div = $("<div></div>").append(def);
 			        			var port = $("<div class='port'></div>").append(h).append(div);
 			        			$("div#enhancedView").append(port);			        			
 			        		};
@@ -299,93 +319,3 @@ function rapper(){
 	
 	}
 
-
-//function addInfo(){
-//	
-//	var glossarcat = $("ul.glossary li[class]");
-//	
-//	
-//	for (var i= 0; i < glossarcat.length; i++) {
-//	
-//		var cat = $(glossarcat[i]);		
-//	
-//		var glossartyp = cat.context.className;
-//	
-//		console.log("das ist der glossartyp")
-//		console.log(glossartyp);
-//		doAnAjax(glossartyp, cat,function(wert, cat){			
-//			console.log(wert);
-//			var neuewerte = cat.attr("value", wert);			
-//			rapper();
-//		}		
-//				
-//		);
-//		
-//		
-//	}
-//	
-//}
-//
-//function doAnAjax(glossartyp,cat ,hisBack){
-//$.ajax({     
-//	url: "/mom/service/getTextfromGlossar",
-//	type:"GET",      
-//	//contentType: "application/xml",     
-//	dataType: "xml",
-//	data: { checktype : glossartyp},
-//	success: function(data, textStatus, jqXHR)
-//	{    	console.log("wann bin ich dran?");
-//	
-//		return hisBack(data.activeElement.value, cat);
-//	},     
-//	error: function(){
-//		$("#result").text("Error: Failed to load script.");
-//
-//		return false;
-//	}    
-//});
-//}
-
-//function transport(){
-//	var sprachwert = "de";
-//	var indexname = "illurk-vocabulary";
-//	console.log("wann komme ich zum Einsatz!!!!!!!!!!!!");
-//	$('li[lemma]').each( function() {
-//		//var entry = $(this)[0].attributes.sublemma.value;
-//		var self = $(this);
-//		if(self[0].attributes.lemma.value == ""){
-//			console.log("no lemma value");
-//		}
-//		else {
-//		console.log(self);
-//		var sublemmawert = self[0].attributes.lemma.value;
-//		var lemmawert = self[0].attributes.lemma.value;		
-//		$.ajax({
-//			url:"/mom/service/sublemma",
-//			type:"GET",
-//			dataType:"xml",
-//			data: {lemma : lemmawert, sprache:sprachwert, index:indexname},
-//			success: function(data, textStatus, jqXHR)			{
-//								
-//				if(data.childNodes[0].childNodes[0] == undefined){
-//					console.log("hallojjjjjjj");
-//						}
-//				else {
-//					var translation = data.childNodes[0].childNodes[0].data;					
-//					self.text(translation);
-//					console.log("was passiert da?");
-//					console.log(self.text(translation));
-//				}
-//				
-//				return true;
-//			},
-//			error: function() {
-//				console.log("Error. Failed to load script.");
-//				return false;
-//			}
-//			
-//		});
-//		}
-//	});
-//	
-//}

--- a/my/XRX/src/mom/app/charter/service/getTextfromGlossar.service.xml
+++ b/my/XRX/src/mom/app/charter/service/getTextfromGlossar.service.xml
@@ -1,95 +1,84 @@
 <xrx:service xmlns:eag="http://www.archivgut-online.de/eag" xmlns:xrx="http://www.monasterium.net/NS/xrx">
-  <xrx:id>tag:www.monasterium.net,2011:/mom/service/getTextfromGlossar</xrx:id>
-  <xrx:title>
-    <xrx:i18n>
-      <xrx:key></xrx:key>
-      <xrx:default></xrx:default>
-    </xrx:i18n>
-  </xrx:title>
-  <xrx:subtitle></xrx:subtitle>
-  <xrx:description></xrx:description>
-  <xrx:author>maburg</xrx:author>
-  <xrx:licence>
-This is a component file of the VdU Software for a Virtual Research Environment for the handling of Medieval charters.
-
-As the source code is available here, it is somewhere between an alpha- and a beta-release, may be changed without any consideration of backward compatibility of other parts of the system, therefore, without any notice.
-
-This file is part of the VdU Virtual Research Environment Toolkit (VdU/VRET).
-
-The VdU/VRET is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-VdU/VRET is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
-  </xrx:licence>
-  <xrx:variables>
-     <xrx:variable>
-      <xrx:name>$getText</xrx:name>  
-      <xrx:expression>request:get-parameter('id', '')</xrx:expression>
-    </xrx:variable>
-       <xrx:variable>
-      <xrx:name>$typ</xrx:name>  
-      <xrx:expression>request:get-parameter('typ', '')</xrx:expression>
-    </xrx:variable>
-   <xrx:variable>
-      <xrx:name>$getTyp</xrx:name>  
-      <xrx:expression>concat('tag:www.monasterium.net,2011:/controlledVocabulary/', request:get-parameter('typ', ''))</xrx:expression>
-    </xrx:variable>
-       <xrx:variable>
-      <xrx:name>$checkType</xrx:name>  
-      <xrx:expression>request:get-parameter('checktype', '')</xrx:expression>
-    </xrx:variable>
-       <xrx:variable>
-      <xrx:name>$checkglossarType</xrx:name>  
-      <xrx:expression>concat('tag:www.monasterium.net,2011:/', $checkType)</xrx:expression>
-    </xrx:variable>
+    <xrx:id>tag:www.monasterium.net,2011:/mom/service/getTextfromGlossar</xrx:id>
+    <xrx:title>
+        <xrx:i18n>
+            <xrx:key></xrx:key>
+            <xrx:default></xrx:default>
+        </xrx:i18n>
+    </xrx:title>
+    <xrx:subtitle></xrx:subtitle>
+    <xrx:description></xrx:description>
+    <xrx:author>maburg</xrx:author>
+    <xrx:licence>
+        This is a component file of the VdU Software for a Virtual Research Environment for the handling of Medieval charters.
         
-  </xrx:variables> 
-  
-  <xrx:init>
-   <xrx:processor>
-     <xrx:translateflag>false</xrx:translateflag>
-   </xrx:processor>
-  </xrx:init>
-  <!-- This service is used to get the entries from a skos file in metadata.glossar.public 
-  the return value is embedded in the single charter view (depends from cei2html.xsl)-->
-  <xrx:body>
-    {    
-
-let $glossarlabel := collection("/db/mom-data/metadata.controlledVocabulary.public/")/atom:entry[atom:id/text()=$getTyp]//skos:Concept[@rdf:about= concat('#', $getText)]/skos:prefLabel/text()
-let $glossardesc := collection("/db/mom-data/metadata.controlledVocabulary.public/")/atom:entry[atom:id/text()=$getTyp]//skos:Concept[@rdf:about= concat('#', $getText)]
-
- let $glossarintro := collection("/db/mom-data/metadata.controlledVocabulary.public/")/atom:entry[atom:id/text()='tag:www.monasterium.net,2011:/controlledVocabulary/IllUrkGlossar']//rdf:RDF/skos:ConceptScheme/skos:note/text()
-
-return 
-if ($checkType) then(
-          let $checkglossar := collection("/db/mom-data/metadata.controlledVocabulary.public/")//atom:id/text()= $checkglossarType
-          return
-          if ($checkglossar = true())then(
-              <p>true</p>
-          )else(
-             <p>false</p>
-          )         
-          ) 
-      else if ($typ = 'bishop') then (
-          let $collection := collection("/db/mom-data/metadata.person.public/")
-          let $inmem := $collection//tei:TEI         
-          let $bishops := data($inmem//tei:person[@xml:id=$getText])    
-          
-          return  <div class="port">{$bishops}</div>
-          )
-          
-      else (      
-         <div class="port">        
-     {$glossardesc}
-        </div>  )
-}
-  </xrx:body>
+        As the source code is available here, it is somewhere between an alpha- and a beta-release, may be changed without any consideration of backward compatibility of other parts of the system, therefore, without any notice.
+        
+        This file is part of the VdU Virtual Research Environment Toolkit (VdU/VRET).
+        
+        The VdU/VRET is free software: you can redistribute it and/or modify
+        it under the terms of the GNU General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version.
+        
+        VdU/VRET is distributed in the hope that it will be useful,
+        but WITHOUT ANY WARRANTY; without even the implied warranty of
+        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+        GNU General Public License for more details.
+        
+        You should have received a copy of the GNU General Public License
+        along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
+    </xrx:licence>
+    <xrx:variables>
+        <xrx:variable>
+            <xrx:name>$getText</xrx:name>  
+            <xrx:expression>request:get-parameter('id', '')</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
+            <xrx:name>$typ</xrx:name>  
+            <xrx:expression>request:get-parameter('typ', '')</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
+            <xrx:name>$category</xrx:name>  
+            <xrx:expression>request:get-parameter('cat', '')</xrx:expression>
+        </xrx:variable>        
+    </xrx:variables> 
+    
+    <xrx:init>
+        <xrx:processor>
+            <xrx:translateflag>false</xrx:translateflag>
+        </xrx:processor>
+    </xrx:init>
+    <!-- 
+    This service is used to get the entries from a skos and TEI files in metadata.controlledVocabulary.public 
+    or metadata.person.public. These 2 cases are considered in the if condition.
+    The $getText has the indexed term that was clicked in the GUI;
+    $typ is the name of the index; 
+    $category is 'person' or 'item', used to differentiate collections.
+    
+    The service is called in charter.js 
+    -->
+    <xrx:body>
+        
+        {   
+        let $atomid := if($category='person') then concat('tag:www.monasterium.net,2011:/person/', $typ)
+        else(concat('tag:www.monasterium.net,2011:/controlledVocabulary/', $typ))
+        
+        let $rightcollection := if($category='person') then collection("/db/mom-data/metadata.person.public/")/atom:entry[atom:id/text()= $atomid]
+                                else(collection("/db/mom-data/metadata.controlledVocabulary.public/")/atom:entry[atom:id/text()=$atomid])
+        return
+        
+        if ($category = 'person') then (              
+        let $persons := $rightcollection//tei:person[@xml:id=$getText]/node()                 
+        return  <div class="port">{$persons}</div>
+        )          
+        else (
+        let $glossarlabel := $rightcollection//skos:Concept[@rdf:about= concat('#', $getText)]/skos:prefLabel/text()
+        let $glossardesc := $rightcollection//skos:Concept[@rdf:about= concat('#', $getText)]
+        return      
+        <div class="port">        
+            {$glossardesc}
+        </div>  ) 
+        }
+    </xrx:body>
 </xrx:service>

--- a/my/XRX/src/mom/app/charter/widget/charter.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/charter.widget.xml
@@ -294,11 +294,11 @@ it leaves the active development stage.
     <xrx:variable>
       <xrx:name>$wcharter:image-base-uri</xrx:name>
       <xrx:expression>
-		if($wcharter:context = 'fond' or $wcharter:context = 'linked-fond') then
-			concat($wcharter:preferences/xrx:param[@name='image-server-base-url']/text(), '/') 
-	  else
-			concat('http://', $wcharter:meta//cei:image_server_address/text(),'/', $wcharter:meta//cei:image_server_folder/text(), '/')
-				</xrx:expression>
+    if($wcharter:context = 'fond' or $wcharter:context = 'linked-fond') then
+      concat($wcharter:preferences/xrx:param[@name='image-server-base-url']/text(), '/') 
+    else
+      concat('http://', $wcharter:meta//cei:image_server_address/text(),'/', $wcharter:meta//cei:image_server_folder/text(), '/')
+        </xrx:expression>
     </xrx:variable>
     <!-- archive information -->
     <xrx:variable>
@@ -308,10 +308,18 @@ it leaves the active development stage.
      <xrx:variable>
         <xrx:name>$wcharter:controlledvocabularies</xrx:name>
     <xrx:expression>       
- for $i in collection("/db/mom-data/metadata.controlledVocabulary.public")//atom:entry//skos:ConceptScheme
+ for $i in collection(concat(conf:param("data-db-base-uri"), "/metadata.controlledVocabulary.public"))//atom:entry//skos:ConceptScheme
 let $vocabular := replace(data($i/@rdf:about), '#', '')
         return $vocabular         
      </xrx:expression>
+    </xrx:variable>
+    <!-- vorhandene Personenlisten auslesen
+         und infolge an XSL übergeben -->
+    <xrx:variable>
+    <xrx:name>$wcharter:personlist</xrx:name>
+    <xrx:expression>for $i in collection(concat(conf:param("data-db-base-uri"), "/metadata.person.public"))//atom:entry/atom:id
+        let $filename := util:document-name($i)
+        return $filename</xrx:expression>
     </xrx:variable>
     <!--  Sprache für Vokabulare ändern? -->    
       <xrx:variable>
@@ -324,7 +332,8 @@ let $vocabular := replace(data($i/@rdf:about), '#', '')
       <xrx:name>$wcharter:xsl</xrx:name>
       <xrx:expression>$xrx:db-base-collection/xsl:stylesheet[@id='cei2html']</xrx:expression>
     </xrx:variable>
-
+<!-- <atom:id>tag:www.monasterium.net,2011:/person/Notarii</atom:id> 
+    <atom:id>tag:www.monasterium.net,2011:/person/CDC-AbatiSanMassimo</atom:id>-->
        <xrx:variable>
       <xrx:name>$wcharter:params</xrx:name>
       <xrx:expression>
@@ -334,6 +343,9 @@ let $vocabular := replace(data($i/@rdf:about), '#', '')
           <param name="sprache" value="{$wcharter:sprache}"/>
 
           <param name="controlledvocabularies" value="{$wcharter:controlledvocabularies}"/>
+          <param name="personfilelist" value="{$wcharter:personlist}">
+            
+          </param>
             {
             let $keys := root($wcharter:xsl)//*[local-name(.) = "stylesheet"]/node()
             let $i18n := $keys//xrx:i18n
@@ -406,9 +418,9 @@ let $vocabular := replace(data($i/@rdf:about), '#', '')
       <xrx:expression>concat($image-tools-base-url, $charter:rcharterid, '/image-tools')</xrx:expression>
     </xrx:variable>
     <xrx:variable>
-    	<xrx:name>$wcharter:owner</xrx:name>
-    	<xrx:expression>if($wcharter:context = "fond") then doc(concat(metadata:base-collection-path('archive', $charter:rarchiveid, 'public'),$charter:rarchiveid, ".eag.xml"))//eag:identity/eag:autform/text()
-    	else (root($wcharter:charter)//atom:email/text())</xrx:expression>
+      <xrx:name>$wcharter:owner</xrx:name>
+      <xrx:expression>if($wcharter:context = "fond") then doc(concat(metadata:base-collection-path('archive', $charter:rarchiveid, 'public'),$charter:rarchiveid, ".eag.xml"))//eag:identity/eag:autform/text()
+      else (root($wcharter:charter)//atom:email/text())</xrx:expression>
     </xrx:variable>
   </xrx:variables>
   <xrx:portal>tag:www.monasterium.net,2011:/mom/portal/charter</xrx:portal>
@@ -1318,22 +1330,22 @@ p#first {{
       {
       if($wcharter:metadata-collection-collection//cei:sourceDesc/cei:p/text() = 'Export aus Google Daten') then
       <div data-demoid="f7495edb-98da-49a6-a16c-ee41e59606d8">
-	      <br/>
-	      <div class="p ocr-hint" data-demoid="38e8611c-6bba-47e9-99c5-61658c9d3d0d">
-	        <div class="ocr-hint-inner" data-demoid="415a1215-9351-451b-90f8-7642bc2d7f95">
-	          <span>
-	            <xrx:i18n>
-	              <xrx:key>ocr-scanned-message</xrx:key>
-	              <xrx:default>The transcription and metadata of this charter are scanned by a OCR tool and thus may have low quality.</xrx:default>
-	            </xrx:i18n>
-	          </span>
-	        </div>
-	      </div>
-	      <br/>
-	    </div>
-		  else()
-		  }
-		  <xrx:div>download-xml-link</xrx:div>
+        <br/>
+        <div class="p ocr-hint" data-demoid="38e8611c-6bba-47e9-99c5-61658c9d3d0d">
+          <div class="ocr-hint-inner" data-demoid="415a1215-9351-451b-90f8-7642bc2d7f95">
+            <span>
+              <xrx:i18n>
+                <xrx:key>ocr-scanned-message</xrx:key>
+                <xrx:default>The transcription and metadata of this charter are scanned by a OCR tool and thus may have low quality.</xrx:default>
+              </xrx:i18n>
+            </span>
+          </div>
+        </div>
+        <br/>
+      </div>
+      else()
+      }
+      <xrx:div>download-xml-link</xrx:div>
       <xrx:subwidget>
         <xrx:atomid>tag:www.monasterium.net,2011:/mom/widget/charter-image-viewer</xrx:atomid>
         <xrx:pass>
@@ -1397,33 +1409,27 @@ p#first {{
       <div data-demoid="1c49211c-4c33-4899-ae42-afc2d1735340">
         <div data-demoid="92fc737f-0034-4bbc-8d4c-42038dfded81" id="image-tool-widget">
           <script type="text/javascript">
-				    $(document).ready(function(){{
-				    	rapper();
-				      proof();
-	            jQuery(document).imageTool({{
-	              requestRoot: "{ conf:param('request-root') }",
-	              charter: "{ $charter:rcharterid }",
-	              collection: "{ if($wcharter:context = 'collection') then $charter:rcollectionid else() }",
-	              scope: "public", 
+            $(document).ready(function(){{
+              addInfo();
+              proof();
+              jQuery(document).imageTool({{
+                requestRoot: "{ conf:param('request-root') }",
+                charter: "{ $charter:rcharterid }",
+                collection: "{ if($wcharter:context = 'collection') then $charter:rcollectionid else() }",
+                scope: "public", 
                 servicePrefix: ""
-	            }});
-	            jQuery(document).i18nText({{
-	              lang: "{ $xrx:lang }",
-	     	        requestRoot: "{ conf:param('request-root') }"
-	     	      }});
-
-	     	   console.log(" aus charter.widget");
-	   var verlinkt = $("div#graphics").find("a#img-link");
-    var missinglink = $("div#graphics").find("div.no-graphic");    
-    console.log(verlinkt);
-    console.log(missinglink);
-	     	  if(verlinkt.length != 0){{
-           console.log("es gibt imgs im viewer");          
-          var x = $("#graphics").css("display", "block");
-          console.log(verlinkt);          
+              }});
+              jQuery(document).i18nText({{
+                lang: "{ $xrx:lang }",
+                requestRoot: "{ conf:param('request-root') }"
+              }});           
+     var verlinkt = $("div#graphics").find("a#img-link");
+    var missinglink = $("div#graphics").find("div.no-graphic");   
+  
+          if(verlinkt.length != 0){{                   
+          var x = $("#graphics").css("display", "block");                
           }}
-          else {{
-          console.log("no-graphic in image-viewer");
+          else {{         
           var x = $("#graphics").css("display", "none");
           }}
            $("div.actions").insertAfter("div#downloads");
@@ -1433,8 +1439,8 @@ p#first {{
           
           }}
 
-				    }});     
-  		    </script>
+            }});     
+          </script>
           <xrx:resource id="image-tool-widget-close-button" title="Close Image Tool" type="image/png">tag:www.monasterium.net,2011:/mom/resource/image/button_close</xrx:resource>
           <div data-demoid="5c794018-378e-4fc8-bbe1-814cd17977c0" id="image-tool-widget-button-bar">
             {
@@ -1529,18 +1535,18 @@ p#first {{
       } 
 
       <div id="copy-legal-popUp" style="display:none">
-      	<div id="dialogcontent">
-      	<span><xrx:i18n><xrx:key>you-are-copying-a-text-from</xrx:key><xrx:default>You are copying a text from</xrx:default></xrx:i18n></span>
-      	<span id="insertOwner"></span>
-      	  <span><xrx:i18n><xrx:key>end-legal-text</xrx:key><xrx:default>into your own collection. Please be aware that reusing it might infringe intellectural property rights, so please check individual licences and cite the source of your information when you publish your data</xrx:default></xrx:i18n></span>
+        <div id="dialogcontent">
+        <span><xrx:i18n><xrx:key>you-are-copying-a-text-from</xrx:key><xrx:default>You are copying a text from</xrx:default></xrx:i18n></span>
+        <span id="insertOwner"></span>
+          <span><xrx:i18n><xrx:key>end-legal-text</xrx:key><xrx:default>into your own collection. Please be aware that reusing it might infringe intellectural property rights, so please check individual licences and cite the source of your information when you publish your data</xrx:default></xrx:i18n></span>
          </div>
         </div>
        <div id="select-collection-popUp" style="display:none">
-      	<div id="dialogcontent">
-      		<select id="collectionSelect">
-      		</select>
-      		<p id="charterexistmessage" style="display:none">The Charter already exists in the choosen Collection</p>
-      		<p id="copyinProgress" style="display:none">Please wait copying Charter, dialog will close at success</p>
+        <div id="dialogcontent">
+          <select id="collectionSelect">
+          </select>
+          <p id="charterexistmessage" style="display:none">The Charter already exists in the choosen Collection</p>
+          <p id="copyinProgress" style="display:none">Please wait copying Charter, dialog will close at success</p>
         </div>
        </div>
       </div>     

--- a/my/XRX/src/mom/app/charter/widget/my-charter.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/my-charter.widget.xml
@@ -41,7 +41,7 @@ it leaves the active development stage.
   </xrx:licence>
   <xrx:variables>
     <!-- 
-    	charter context: collection or fond? 
+      charter context: collection or fond? 
     -->
     <xrx:variable>
       <xrx:name>$wcharter:context</xrx:name>
@@ -62,7 +62,7 @@ it leaves the active development stage.
       </xrx:expression>
     </xrx:variable>
     <!-- 
-    	init metadata database collections 
+      init metadata database collections 
     -->
     <xrx:variable>
       <xrx:name>$wcharter:tokens</xrx:name>
@@ -160,8 +160,8 @@ it leaves the active development stage.
       <xrx:expression>charter:position($wcharter:charters, $wcharter:private-charter, $xrx:user-xml, $wcharter:atom-id, $xrx:tokenized-uri[last()])</xrx:expression>
     </xrx:variable>
     <!-- 
-		  back link to fond or collection 
-		-->
+      back link to fond or collection 
+    -->
     <xrx:variable>
       <xrx:name>$wcharter:block</xrx:name>
       <xrx:expression>charter:block(xs:integer($wcharter:pos))</xrx:expression>
@@ -171,8 +171,8 @@ it leaves the active development stage.
       <xrx:expression>charter:anchor(xs:integer($wcharter:pos))</xrx:expression>
     </xrx:variable>
     <!-- 
-		  status of the charter 
-		-->
+      status of the charter 
+    -->
     <xrx:variable>
       <xrx:name>$wcharter:is-bookmarked</xrx:name>
       <xrx:expression>false()</xrx:expression>
@@ -204,25 +204,21 @@ it leaves the active development stage.
       <xrx:name>$wcharter:archive</xrx:name>
       <xrx:expression>$wcharter:metadata-archive-collection//eag:autform/text()</xrx:expression>
     </xrx:variable>
-    <!-- 
-      XSLT transformation
-     -->
-    <xrx:variable>
+     <xrx:variable>
         <xrx:name>$wcharter:controlledvocabularies</xrx:name>
     <xrx:expression>       
- for $i in collection("/db/mom-data/metadata.controlledVocabulary.public")//atom:entry//skos:ConceptScheme
+ for $i in collection(concat(conf:param("data-db-base-uri"), "/metadata.controlledVocabulary.public"))//atom:entry//skos:ConceptScheme
 let $vocabular := replace(data($i/@rdf:about), '#', '')
         return $vocabular         
      </xrx:expression>
     </xrx:variable>
-   <xrx:variable>
-    <xrx:name>$wcharter:page</xrx:name>
-    <xrx:expression>
-       <page>      
-         { template:get('tag:www.monasterium.net,2011:/mom/template/charter-view', false()) }
-          { util:expand($wcharter:charter) }
-        </page>
-    </xrx:expression>
+    <!-- vorhandene Personenlisten auslesen
+         und infolge an XSL übergeben -->
+    <xrx:variable>
+    <xrx:name>$wcharter:personlist</xrx:name>
+    <xrx:expression>for $i in collection(concat(conf:param("data-db-base-uri"), "/metadata.person.public"))//atom:entry/atom:id
+        let $filename := util:document-name($i)
+        return $filename</xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wcharter:xsl</xrx:name>
@@ -235,6 +231,7 @@ let $vocabular := replace(data($i/@rdf:about), '#', '')
           <param name="image-base-uri" value="{ $wcharter:image-base-uri }"/>
           <param name="sprache" value="{$xrx:lang}"/>
           <param name="controlledvocabularies" value="{$wcharter:controlledvocabularies}"/>
+          <param name="personfilelist" value="{$wcharter:personlist}"/>
           {
             let $keys := root($wcharter:xsl)//*[local-name(.) = "stylesheet"]/node()
             let $i18n := $keys//xrx:i18n
@@ -429,8 +426,6 @@ jQuery(document).ready(function() {{
       </a>       
     </div>
 </form> 
-<!-- javascript:transport();
- javascript:proof(); javascript:addInfo();-->
  <script type="text/javascript">
 $( "#radio" ).buttonset();
   
@@ -438,22 +433,18 @@ $( "#radio" ).buttonset();
     
 $(".open-viewer-link").hide();
 $("#zoomsliderlabel").hide();
- javascript:rapper();
+ javascript:addInfo();
  javascript:proof();   
 
- console.log('my-charter.widget');
 
     var verlinkt = $("div#graphics").find("a#img-link");
-    var missinglink = $("div#graphics").find("div.no-graphic");    
-    console.log(verlinkt);
-    console.log(missinglink);
+    var missinglink = $("div#graphics").find("div.no-graphic");  
     if(verlinkt.length != 0){{
-           console.log("es gibt imgs im viewer");          
+             
           var x = $("#graphics").css("display", "block");
                     
           }}
-          else {{
-          console.log("no-graphic in image-viewer");
+          else {{     
           var x = $("#graphics").css("display", "none");
           }}      
  }});


### PR DESCRIPTION
geht um Urkundeneinzelansicht und die Anzeige vom Index.
Wenn zusätzliche Info zu Schlagwörtern (in skos) und Personen (in tei) vorhanden sind, wird sie über klicken angezeigt. Das ging bisher nur für "Index der Bischöfe" und "Illuminierte Urkunden Glossar",
aber nun auch für "Illuminierte Urkunden Niveaus" und auch andere Personenlisten. siehe:
https://dev.monasterium.net/mom/IlluminierteUrkunden/1005-08-25_Dijon/charter?q=
da hab ich einen person key einer neuen personenliste hinzugefügt.
+ generell Anwendung aufgeräumt.
