### PR TITLE
link from archives to search2 and refactoring of search2

### DIFF
--- a/my/XRX/src/mom/app/archive/widget/archive.widget.xml
+++ b/my/XRX/src/mom/app/archive/widget/archive.widget.xml
@@ -286,7 +286,7 @@ div#archive div#container {{
 				<div data-demoid="ca52ba2c-9366-4679-ba18-6323cdfbd919" id="container">
 					<div data-demoid="119aa847-ef57-4fbc-83ac-4cab9684ced7" id="goto-search">		
 
-						<a href="{ conf:param('request-root') }search?q=&amp;img=false&amp;sort=date&amp;arch={ $archive-id }&amp;p=search">
+						<a href="{ conf:param('request-root') }search2?q=&amp;arch={ $archive-id }">
 							<xrx:i18n>
 								<xrx:key>search-in</xrx:key>
 								<xrx:default>Search in</xrx:default>

--- a/my/XRX/src/mom/app/charters/widget/goto-search.widget.xml
+++ b/my/XRX/src/mom/app/charters/widget/goto-search.widget.xml
@@ -79,7 +79,7 @@ it leaves the active development stage.
         </a> )
     }      
       </div>
-             <a href="{ conf:param('request-root') }search?q=&amp;img=false&amp;sort=date&amp;arch={ $wgoto-search:id }&amp;p=search">
+             <a href="{ conf:param('request-root') }search2?q=&amp;arch={ $wgoto-search:id }">
               <xrx:i18n>
                 <xrx:key>search-in</xrx:key>
                 <xrx:default>Search in</xrx:default>
@@ -109,6 +109,7 @@ it leaves the active development stage.
         </a> 
         )  }   
       </div>
+      <div>
           <a href="{ conf:param('request-root') }{ $wgoto-search:id }/annotation-overview">
             <xrx:i18n>
               <xrx:key>annotation-overview</xrx:key>
@@ -116,6 +117,16 @@ it leaves the active development stage.
             </xrx:i18n>
             <span>  &gt;&gt;</span>
           </a>
+          </div>
+          <div>
+           <a href="{ conf:param('request-root') }search2?q=&amp;arch={ $wgoto-search:id }">
+              <xrx:i18n>
+                <xrx:key>search-in-collection</xrx:key>
+                <xrx:default>Search in this collection</xrx:default>
+              </xrx:i18n>            
+              <span>&gt;&gt;</span>
+          </a>
+          </div>
      </div>    
     else( <div data-demoid="548bbfaa-a9ba-4ad8-aea2-cac5c7f5a76b" id="goto-anno-overview" class="goto">
         <div>        

--- a/my/XRX/src/mom/app/search/js/jquery.ui.search.js
+++ b/my/XRX/src/mom/app/search/js/jquery.ui.search.js
@@ -165,6 +165,12 @@ $.widget("ui.search", {
 
   _initContext: function() {	
     var str = []; 
+    /* when link from colltection/archive page to search2
+     *  then get-parameter 'q' is empty but 'arch' has a value
+     *  the value of arch is taken and pushed in the 'str' array
+     *  the array is then handed over to the input value
+     *   of the context-search
+     *  */
      var suchstring = window.location.search;
       var sauber = suchstring.replace(/\+/g, ' ');
       var uridec = decodeURIComponent(sauber); 

--- a/my/XRX/src/mom/app/search/js/jquery.ui.search.js
+++ b/my/XRX/src/mom/app/search/js/jquery.ui.search.js
@@ -28,6 +28,7 @@ $.widget("ui.search", {
     this._initFilter();
     this._initContext();
     this._initTrigger();
+    console.log("was passiert hier?")
   },
 
 
@@ -129,9 +130,7 @@ $.widget("ui.search", {
     $(selCheckbox_, "#categories-result").each(function() {
       if (this.checked) str.push($(this).attr('name'));
     });
-
-    $("#categories-search").val(str.join(","));    
-    
+    $("#categories-search").val(str.join(","));
     // select and deselect search categories
     $(selCheckbox_, "#categories-result").change(function() {
       var str = [];
@@ -163,22 +162,37 @@ $.widget("ui.search", {
   },
 
 
-  _initContext: function() {
+  _initContext: function() {	
     var str = [];
+    console.log("init context arch select");
+    //console.log($("#arch-select"));
+    console.log(window.location.search); //?arch=
+   /* $("#arch-select").menu();
+    $("#arch-select").change(function() {
+    console.log("Wert in select");
+   	var name = this.value;    	 
+    $(this).children().removeAttr("selected", "selected");
+  	$("option[value =" + name + "]").attr("selected", "selected");  
+   })*/
+    //<select id="arch-select" name="context">
+    /*$("#arch-select").change(function() {
+        var str = [];
+        $(selCheckbox_, "#context-result").each(function() {
+          if (this.checked) str.push($(this).attr('name'));
+        });*/
+    
     $(selCheckbox_, "#context-result").each(function() {
       if (this.checked) str.push($(this).attr('name'));
     });
-
-    $("#context-search").val(str.join(","));    
-    
+    $("#context-search").val(str.join(","));
     // select and deselect archives / collections
     $(selCheckbox_, "#context-result").change(function() {
       var str = [];
       $(selCheckbox_, "#context-result").each(function() {
         if (this.checked) str.push($(this).attr('name'));
       });
-
-      $("#context-search").val(str.join(","));
+    
+      $("#context-search").val(str.join(",")); 
     });
   },
 

--- a/my/XRX/src/mom/app/search/js/jquery.ui.search.js
+++ b/my/XRX/src/mom/app/search/js/jquery.ui.search.js
@@ -164,36 +164,34 @@ $.widget("ui.search", {
 
 
   _initContext: function() {	
-    var str = [];
-    console.log("init context arch select");
-    //console.log($("#arch-select"));
-    console.log(window.location.search); //?arch=
-   /* $("#arch-select").menu();
-    $("#arch-select").change(function() {
-    console.log("Wert in select");
-   	var name = this.value;    	 
-    $(this).children().removeAttr("selected", "selected");
-  	$("option[value =" + name + "]").attr("selected", "selected");  
-   })*/
-    //<select id="arch-select" name="context">
-    /*$("#arch-select").change(function() {
-        var str = [];
-        $(selCheckbox_, "#context-result").each(function() {
-          if (this.checked) str.push($(this).attr('name'));
-        });*/
-    
+    var str = []; 
+     var suchstring = window.location.search;
+      var sauber = suchstring.replace(/\+/g, ' ');
+      var uridec = decodeURIComponent(sauber); 
+      var params = uridec.split("?")[1];
+      
+      if (params != null ){
+    	  if (params.includes("arch="))
+    	     {
+    	    	  var wert = params.substring(params.indexOf("arch="), params.length).split("arch=")[1];    	    	 
+    	    	  str.push(wert);
+    	    	  $("#context-search").val(str.join(","));
+    	      }
+      }
+
     $(selCheckbox_, "#context-result").each(function() {
       if (this.checked) str.push($(this).attr('name'));
     });
 
     $("#context-search").val(str.join(","));
+    
     // select and deselect archives / collections
     $(selCheckbox_, "#context-result").change(function() {
       var str = [];
       $(selCheckbox_, "#context-result").each(function() {
         if (this.checked) str.push($(this).attr('name'));
       });
-    
+   
       $("#context-search").val(str.join(",")); 
     });
   },

--- a/my/XRX/src/mom/app/search/search.xqm
+++ b/my/XRX/src/mom/app/search/search.xqm
@@ -71,10 +71,10 @@ declare variable $search:CONTEXT_FILTERED := 'archives-filtered';
 declare variable $search:HITS := 'hits';
 declare variable $search:HITS_FILTERED := 'hits-filtered';
 declare variable $search:QUERY := 'query';
-declare variable $search:Q := 'searchterm';
+declare variable $search:QUERY_TERM := 'searchterm';
 declare variable $search:ATTRIBUTES := ($search:RESULT, $search:CATEGORIES,
     $search:CATEGORIES_FILTERED, $search:CONTEXT, $search:CONTEXT_FILTERED,
-    $search:HITS, $search:HITS_FILTERED, $search:QUERY, $search:Q);
+    $search:HITS, $search:HITS_FILTERED, $search:QUERY, $search:QUERY_TERM);
 
 
 
@@ -471,8 +471,8 @@ declare function search:eval2($query-string) {
     if(search:is-browse-action($query-string)) then ()    
         
     else if(search:is-first-action()) then     
-        let $set := session:set-attribute($search:Q, $search:q)
-        (: $search:Q is used to remember if the users called the search:is-first-action() :)
+        let $set := session:set-attribute($search:QUERY_TERM, $search:q)
+        (: $search:QUERY_TERM is used to remember if the users called the search:is-first-action() :)
         let $result := util:eval($query-string)
         
         let $map := search:compile-categories-map($result)        
@@ -509,7 +509,7 @@ declare function search:eval2($query-string) {
          if the user copies a query URL or is linked from the archive or collection widget
           then the categories are set for the first time, the user has no search history          
          it is the same with the contexts  :)
-       let $do := if(session:get-attribute($search:Q) = $search:q) then search:set-categories-filtered($map, ())
+       let $do := if(session:get-attribute($search:QUERY_TERM) = $search:q) then search:set-categories-filtered($map, ())
        else(let $do := search:set-categories($map)
              let $do := search:set-categories-filtered($map, 
                   session:get-attribute($search:CATEGORIES))
@@ -517,7 +517,7 @@ declare function search:eval2($query-string) {
                      
         let $result := search:filter-result($result, $map)     
         
-        let $do := if(session:get-attribute($search:Q) = $search:q) then search:set-context-filtered($result, ()) 
+        let $do := if(session:get-attribute($search:QUERY_TERM) = $search:q) then search:set-context-filtered($result, ()) 
         else(let $do := search:set-context($result)
              let $do := search:set-context-filtered($result, 
                 session:get-attribute($search:CONTEXT))

--- a/my/XRX/src/mom/app/search/widget/search2.widget.xml
+++ b/my/XRX/src/mom/app/search/widget/search2.widget.xml
@@ -311,78 +311,10 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
             <xrx:default>Search</xrx:default>
           </xrx:i18n>
           </div>
-          <input id="search-field" name="q" type="text" value=""/>
-          <input id="search-trigger" type="submit" value=""/>
+       <input id="search-field" name="q" type="text" value="{request:get-parameter('q', '')}"/>         
+          <input id="search-trigger" type="submit" value="{i18n:value('search', $xrx:lang, 'Search')}"/>
           <xrx:div>search-options-div</xrx:div>
-          <xrx:div>search2-description</xrx:div>
-                  <div data-demoid="11541057-2e82-4230-a416-2f446d078930" id="confine">
-          <b>
-            <xrx:i18n>
-              <xrx:key>confine-search-scope</xrx:key>
-              <xrx:default>Confine Search Scope</xrx:default>
-            </xrx:i18n>
-            <span>:</span>
-          </b>
-          <div class="confine-label" data-demoid="c99f1a1c-ee40-4969-822b-ac1ddf0fea1c">
-            <xrx:i18n>
-              <xrx:key>select-archive</xrx:key>
-              <xrx:default>Select Archive</xrx:default>
-            </xrx:i18n>
-            <span>: </span>
-          </div>
-    <!--   {     let $select-archive-div := 
-    <select id="arch-select" onchange="location = this.value;">
-        <option value="" selected="selected">
-          <xrx:i18n>
-            <xrx:key>all-archives</xrx:key>
-            <xrx:default>All archives</xrx:default>
-          </xrx:i18n>
-        </option>
-      {
-      for $archive in metadata:base-collection('archive', 'public')//eag:eag
-      let $autform := $archive//eag:autform/text() 
-      let $repositorid := $archive//eag:repositorid/text()
-      order by $autform collation "?lang=de-DE"
-      return
-      <option value="?arch={ $repositorid }">{$autform }</option>
-      }
-    </select>
-    return $select-archive-div } -->
-   <!--    {
-      if(request:get-parameter('arch', '') != '') then
-      <div data-demoid="e43712c2-af56-4a43-9fb3-f83d09bd55ff">
-            <div class="confine-label" data-demoid="d8709d92-a01b-4e8e-b6c6-7d571f88f5b8">
-              <xrx:i18n>
-                <xrx:key>select-fond</xrx:key>
-                <xrx:default>Select Fond</xrx:default>
-              </xrx:i18n>
-              <span>: </span>
-            </div>
-   {   let $select-col-div :=
-    <select id="col-select" name="col" >
-        <option value="">
-          <xrx:i18n>
-            <xrx:key>all-fonds</xrx:key>
-            <xrx:default>All fonds</xrx:default>
-          </xrx:i18n>
-        </option>
-    {
-    if($search:arch-id != '') then
-    let $metadata-fond-collection := metadata:base-collection('fond', $search:arch-id, 'public')
-    for $fond in $metadata-fond-collection//ead:c[@level='fonds']/ead:did/ead:unittitle
-    let $fond-name := normalize-space($fond/child::text())
-    let $search:fond-id := $fond/parent::ead:did/ead:unitid/@identifier/string()
-    order by $fond-name collation "?lang=de-DE"
-    return
-    <option value="{ $search:fond-id }">{ $fond-name }</option>
-    else ()
-    }
-    </select>
-   return $select-col-div }
-        </div>
-      else()
-      }  -->
-    </div>
+          <xrx:div>search2-description</xrx:div>          
         </div>
       </xrx:view>
     </xrx:div>
@@ -457,7 +389,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
               <xrx:key>no-results-message</xrx:key>
               <xrx:default>No results were found for your search.</xrx:default>
             </xrx:i18n>
-          </span>
+          </span>         
           </div>
           else()
           }
@@ -468,9 +400,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
         <br/>
         <input id="categories-search" name="categories" type="hidden" value=""/>
         <input id="context-search" name="context" type="hidden" value=""/>
-      </form>
-       
-      <diV>DIE HITS: {$wsearch:count}</diV>
+      </form>     
       {       
       if($wsearch:count != 0) then 
       <div data-demoid="46eda2fa-8442-4a23-a974-4fa3ab442f24" id="result">
@@ -521,21 +451,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
         </div>
         <br/>     
          <xrx:div>select-block-div</xrx:div> 
-        <div data-demoid="a078f212-5a9e-4d16-8de6-17a8e5b2507e">&lt;{ normalize-space($search:q) }&gt;
-       <!-- maybe improvement of search usability: tbc <p>
-          {
-        let $contexte := request:get-parameter('context', '')        
-        return if($contexte) then 
-        <span class="light-grey"><xrx:i18n><xrx:key>search_context</xrx:key><xrx:default>My Search contexts</xrx:default></xrx:i18n><span>: </span>{$contexte}</span>
-        else()
-        }<br/>
-         {
-        let $categories := request:get-parameter('categories', '')
-        return if($categories) then
-        <span class="light-grey"><xrx:i18n><xrx:key>my_search_categories</xrx:key><xrx:default>My Search categories</xrx:default></xrx:i18n><span>: </span>{$categories}</span>
-        else()
-       
-        }</p>  -->
+        <div data-demoid="a078f212-5a9e-4d16-8de6-17a8e5b2507e">&lt;{ normalize-space($search:q) }&gt; 
         </div>        
         <br/><br/>
         <div data-demoid="3d0a1ccd-8fb3-467c-8546-de74d8b22841" id="result-options">
@@ -594,12 +510,6 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
                 else()
                                                        
                 }         
-             <!--   {
-                if($key = search:categories()) then
-                  attribute checked { 'checked' }
-                else ()
-                } --> 
-        
               </input>
               <span>{ if($count-filtered = '0') then attribute class { 'light-grey' } else() }{ $category/@name/string() } ({ $count-filtered })</span>
               <span class="light-grey"> ({ $count })</span>
@@ -734,8 +644,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
             let $count-filtered := if($filtered/@count) then $filtered/@count/string() else '0'
             order by xs:integer($count-filtered) descending, xs:integer($count) descending
             return
-            <div data-demoid="eb4623d9-ed36-42be-9c0d-8e26df033a59">
-            <div>Filter: {data($filtered/@key)}</div>
+            <div data-demoid="eb4623d9-ed36-42be-9c0d-8e26df033a59">            
               <input name="{ $key }" type="checkbox" class="collection_checkbox">
                {
                 if ($search:context) then
@@ -744,9 +653,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
                 else if (not(deep-equal($wsearch:context, $wsearch:context-filtered)) and $filtered) then attribute checked {'checked'}
                 else()
                                                        
-                }</input>                
-     
-              
+                }</input>              
              
               <span title="{ $name }">{ if($count-filtered = '0') then attribute class { 'light-grey' } else() }{ $collection/@name/string() } ({ $count-filtered })</span>
               <span class="light-grey"> ({ $count })</span>
@@ -758,8 +665,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
              
           </div>
         </div>
-        <div data-demoid="bceb746e-7a77-4337-8e07-4f8b49e7388f" id="dcharter-preview-main">
-        <div>der Suchstring: {$wsearch:query-string}</div>     
+        <div data-demoid="bceb746e-7a77-4337-8e07-4f8b49e7388f" id="dcharter-preview-main">         
           {      
           for $charter at $num in session:get-attribute($search:RESULT)[ position() = $wsearch:start to $wsearch:stop ]
           return

--- a/my/XRX/src/mom/app/search/widget/search2.widget.xml
+++ b/my/XRX/src/mom/app/search/widget/search2.widget.xml
@@ -61,8 +61,8 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
       <xrx:expression>session:get-attribute($search:CONTEXT_FILTERED)</xrx:expression>
     </xrx:variable>
     <xrx:variable>
-      <xrx:name>$wsearch:count</xrx:name>
-      <xrx:expression>xs:integer(session:get-attribute($search:HITS)//*:count/text())</xrx:expression>
+      <xrx:name>$wsearch:count</xrx:name>      
+       <xrx:expression>xs:integer(session:get-attribute($search:HITS)//*:count/text())</xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$wsearch:count-filtered</xrx:name>
@@ -245,13 +245,15 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
 
     </style>
   </xrx:csss>
-  <xrx:jss> 
+  <xrx:jss>
        <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/jquery</xrx:resource>
         <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/external/mousewheel</xrx:resource>
         <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/ui/core</xrx:resource>
         <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/ui/widget</xrx:resource>
         <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/ui/mouse</xrx:resource>
         <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/ui/slider</xrx:resource>
+        <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/ui/menu</xrx:resource>
+        <xrx:resource>tag:www.monasterium.net,2011:/xrx/resource/jquery/ui/accordion</xrx:resource>
     <xrx:resource>tag:www.monasterium.net,2011:/core/resource/jquery/xrx</xrx:resource>    
     <xrx:resource>tag:www.monasterium.net,2011:/mom/resource/jquery/ui/search</xrx:resource>    
    <xrx:resource>tag:www.monasterium.net,2011:/mom/resource/js/toggle_checkbox</xrx:resource>  
@@ -309,10 +311,78 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
             <xrx:default>Search</xrx:default>
           </xrx:i18n>
           </div>
-          <input id="search-field" name="q" type="text" value="{ request:get-parameter('q', '') }"/>
-          <input id="search-trigger" type="submit" value="{ i18n:value('search', $xrx:lang, 'Search') }"/>
+          <input id="search-field" name="q" type="text" value=""/>
+          <input id="search-trigger" type="submit" value=""/>
           <xrx:div>search-options-div</xrx:div>
           <xrx:div>search2-description</xrx:div>
+                  <div data-demoid="11541057-2e82-4230-a416-2f446d078930" id="confine">
+          <b>
+            <xrx:i18n>
+              <xrx:key>confine-search-scope</xrx:key>
+              <xrx:default>Confine Search Scope</xrx:default>
+            </xrx:i18n>
+            <span>:</span>
+          </b>
+          <div class="confine-label" data-demoid="c99f1a1c-ee40-4969-822b-ac1ddf0fea1c">
+            <xrx:i18n>
+              <xrx:key>select-archive</xrx:key>
+              <xrx:default>Select Archive</xrx:default>
+            </xrx:i18n>
+            <span>: </span>
+          </div>
+    <!--   {     let $select-archive-div := 
+    <select id="arch-select" onchange="location = this.value;">
+        <option value="" selected="selected">
+          <xrx:i18n>
+            <xrx:key>all-archives</xrx:key>
+            <xrx:default>All archives</xrx:default>
+          </xrx:i18n>
+        </option>
+      {
+      for $archive in metadata:base-collection('archive', 'public')//eag:eag
+      let $autform := $archive//eag:autform/text() 
+      let $repositorid := $archive//eag:repositorid/text()
+      order by $autform collation "?lang=de-DE"
+      return
+      <option value="?arch={ $repositorid }">{$autform }</option>
+      }
+    </select>
+    return $select-archive-div } -->
+   <!--    {
+      if(request:get-parameter('arch', '') != '') then
+      <div data-demoid="e43712c2-af56-4a43-9fb3-f83d09bd55ff">
+            <div class="confine-label" data-demoid="d8709d92-a01b-4e8e-b6c6-7d571f88f5b8">
+              <xrx:i18n>
+                <xrx:key>select-fond</xrx:key>
+                <xrx:default>Select Fond</xrx:default>
+              </xrx:i18n>
+              <span>: </span>
+            </div>
+   {   let $select-col-div :=
+    <select id="col-select" name="col" >
+        <option value="">
+          <xrx:i18n>
+            <xrx:key>all-fonds</xrx:key>
+            <xrx:default>All fonds</xrx:default>
+          </xrx:i18n>
+        </option>
+    {
+    if($search:arch-id != '') then
+    let $metadata-fond-collection := metadata:base-collection('fond', $search:arch-id, 'public')
+    for $fond in $metadata-fond-collection//ead:c[@level='fonds']/ead:did/ead:unittitle
+    let $fond-name := normalize-space($fond/child::text())
+    let $search:fond-id := $fond/parent::ead:did/ead:unitid/@identifier/string()
+    order by $fond-name collation "?lang=de-DE"
+    return
+    <option value="{ $search:fond-id }">{ $fond-name }</option>
+    else ()
+    }
+    </select>
+   return $select-col-div }
+        </div>
+      else()
+      }  -->
+    </div>
         </div>
       </xrx:view>
     </xrx:div>
@@ -336,6 +406,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
       <xrx:view>
         <div class="select-block" data-demoid="b37e0472-9a95-404d-a464-11d416ec2a88">
           {
+         
           let $block-link := 
           string-join(
             for $param in request:get-parameter-names()
@@ -353,6 +424,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
             </a>
             <span> </span>
           </div>
+          
           }
         </div>
       </xrx:view>
@@ -396,8 +468,10 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
         <br/>
         <input id="categories-search" name="categories" type="hidden" value=""/>
         <input id="context-search" name="context" type="hidden" value=""/>
-      </form> 
-      { 
+      </form>
+       
+      <diV>DIE HITS: {$wsearch:count}</diV>
+      {       
       if($wsearch:count != 0) then 
       <div data-demoid="46eda2fa-8442-4a23-a974-4fa3ab442f24" id="result">
         <div data-demoid="addea255-e7ff-43c6-be01-2357edd28ad2" id="back">
@@ -446,7 +520,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
           <b class="light-grey"> ({ $wsearch:count })</b>
         </div>
         <br/>     
-        <xrx:div>select-block-div</xrx:div>
+         <xrx:div>select-block-div</xrx:div> 
         <div data-demoid="a078f212-5a9e-4d16-8de6-17a8e5b2507e">&lt;{ normalize-space($search:q) }&gt;
        <!-- maybe improvement of search usability: tbc <p>
           {
@@ -511,12 +585,21 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
             order by xs:integer($count-filtered) descending, xs:integer($count) descending
             return
             <div data-demoid="8d173333-510e-4311-abd4-8e190780fdc1">
-              <input name="{ $key }" type="checkbox" class="category_checkbox">
-                {
+              <input name="{ $key }" type="checkbox" class="category_checkbox"> 
+              {
+                if ($search:context) then
+                let $tok := tokenize(xmldb:decode($search:categories), ',')
+                return if($key = $tok) then attribute checked { 'checked' } else()                
+                else if (not(deep-equal($wsearch:categories, $wsearch:categories-filtered)) and $filtered) then attribute checked {'checked'}
+                else()
+                                                       
+                }         
+             <!--   {
                 if($key = search:categories()) then
                   attribute checked { 'checked' }
                 else ()
-                }
+                } --> 
+        
               </input>
               <span>{ if($count-filtered = '0') then attribute class { 'light-grey' } else() }{ $category/@name/string() } ({ $count-filtered })</span>
               <span class="light-grey"> ({ $count })</span>
@@ -599,7 +682,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
             let $archive-name := $archive-entry//eag:autform/text()
             
             let $count := $fond/@count/string()
-            let $filtered := $wsearch:context-filtered//*:fond[@key=$key]
+            let $filtered := $wsearch:context-filtered//*:fond[@name=$key]
             let $count-filtered := if($filtered/@count) then $filtered/@count/string() else '0'
 
            
@@ -611,17 +694,21 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
               else ''}
 
               <input name="{ $key }" type="checkbox" class="fond_checkbox">
-                {
-                if($key = search:context() or empty(search:context())) then
-                  attribute checked { 'checked' }
-                else ()
-                }
+              {
+                if ($search:context) then
+                let $tok := tokenize(xmldb:decode($search:context), ',')
+                return if($key = $tok) then attribute checked { 'checked' } else()                
+                else if (not(deep-equal($wsearch:context, $wsearch:context-filtered)) and $filtered) then attribute checked {'checked'}
+                else()
+                                                       
+                }            
               </input>
 
-              <span title="{ $fond-name }" class="{data($fond/@name)}">{ $fond-key } </span>
-             <!--  { if($count-filtered = '0') then attribute class { 'light-grey' } else() }{ $fond-key } ({ $count-filtered }) -->
+              <span title="{ $fond-name }" name="{data($fond/@name)}">
+              { if($count-filtered = '0') then attribute class { 'light-grey' } else() }  { $fond-key } ({ $count-filtered })           
+             </span>             
               <span class="light-grey"> ({ $count })</span>         
-            </div>
+            </div>          
             </div>
             }
             <div class="confine-trigger-div" data-demoid="d34b830b-d2f7-458a-b26f-435394d85772">
@@ -648,13 +735,19 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
             order by xs:integer($count-filtered) descending, xs:integer($count) descending
             return
             <div data-demoid="eb4623d9-ed36-42be-9c0d-8e26df033a59">
+            <div>Filter: {data($filtered/@key)}</div>
               <input name="{ $key }" type="checkbox" class="collection_checkbox">
-                {
-                if($key = search:context() or empty(search:context())) then
-                  attribute checked { 'checked' }
-                else ()
-                }
-              </input>
+               {
+                if ($search:context) then
+                let $tok := tokenize(xmldb:decode($search:context), ',')
+                return if($key = $tok) then attribute checked { 'checked' } else()                
+                else if (not(deep-equal($wsearch:context, $wsearch:context-filtered)) and $filtered) then attribute checked {'checked'}
+                else()
+                                                       
+                }</input>                
+     
+              
+             
               <span title="{ $name }">{ if($count-filtered = '0') then attribute class { 'light-grey' } else() }{ $collection/@name/string() } ({ $count-filtered })</span>
               <span class="light-grey"> ({ $count })</span>
             </div>
@@ -662,10 +755,12 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
             <div class="confine-trigger-div" data-demoid="75603079-1b52-4ecd-91e5-1c4cd7221c7e">
               <input class="confine-trigger" type="submit" value="→"/>
             </div>
+             
           </div>
         </div>
         <div data-demoid="bceb746e-7a77-4337-8e07-4f8b49e7388f" id="dcharter-preview-main">
-          {
+        <div>der Suchstring: {$wsearch:query-string}</div>     
+          {      
           for $charter at $num in session:get-attribute($search:RESULT)[ position() = $wsearch:start to $wsearch:stop ]
           return
           <xrx:subwidget>
@@ -680,10 +775,10 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
                 <xrx:expression>$num + $wsearch:start -1</xrx:expression>
               </xrx:parameter>
             </xrx:pass>
-          </xrx:subwidget>
-          }
+          </xrx:subwidget>         
+         }
         </div>
-        <xrx:div>select-block-div</xrx:div>
+      <xrx:div>select-block-div</xrx:div>
       </div>
      else() 
       }
@@ -697,3 +792,4 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
     </script>
   </xrx:view>
 </xrx:widget>
+

--- a/my/XRX/src/mom/app/search/widget/search2.widget.xml
+++ b/my/XRX/src/mom/app/search/widget/search2.widget.xml
@@ -398,6 +398,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
         <span>   </span>
         <br/>
         <br/>
+        <!-- the value or these inputs is defined in jquery.ui.search.js -->
         <input id="categories-search" name="categories" type="hidden" value=""/>
         <input id="context-search" name="context" type="hidden" value=""/>
       </form>     
@@ -481,7 +482,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
           </div>
           <div class="confine-trigger-div" data-demoid="c3e90bbd-6e74-45e4-a6e3-7d6e76dce2b4">
             <input class="confine-trigger" type="submit" value="→"/>
-          </div>
+          </div>          
           <div data-demoid="68ed9142-41df-4c6a-bb13-c667650e0c03" id="categories-result">
             <b>
               <xrx:i18n>
@@ -618,8 +619,8 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
               { if($count-filtered = '0') then attribute class { 'light-grey' } else() }  { $fond-key } ({ $count-filtered })           
              </span>             
               <span class="light-grey"> ({ $count })</span>         
-            </div>          
             </div>
+            </div>         
             }
             <div class="confine-trigger-div" data-demoid="d34b830b-d2f7-458a-b26f-435394d85772">
               <input class="confine-trigger" type="submit" value="→"/>
@@ -637,14 +638,13 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
             for $collection in $wsearch:context//*:collection
             let $key := $collection/@key/string()
             let $atomid := metadata:atomid('collection', $key)
-            let $entry := metadata:base-collection('collection', 'public')//atom:id[.=$atomid]/parent::atom:entry
-            let $name := ''
+            let $entry := metadata:base-collection('collection', 'public')//atom:id[.=$atomid]/parent::atom:entry            
             let $count := $collection/@count/string()
             let $filtered := $wsearch:context-filtered//*:collection[@key=$key]
             let $count-filtered := if($filtered/@count) then $filtered/@count/string() else '0'
             order by xs:integer($count-filtered) descending, xs:integer($count) descending
             return
-            <div data-demoid="eb4623d9-ed36-42be-9c0d-8e26df033a59">            
+            <div data-demoid="eb4623d9-ed36-42be-9c0d-8e26df033a59">                       
               <input name="{ $key }" type="checkbox" class="collection_checkbox">
                {
                 if ($search:context) then
@@ -655,14 +655,14 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
                                                        
                 }</input>              
              
-              <span title="{ $name }">{ if($count-filtered = '0') then attribute class { 'light-grey' } else() }{ $collection/@name/string() } ({ $count-filtered })</span>
-              <span class="light-grey"> ({ $count })</span>
+              <span title="{ $collection/@name/string() }">{ if($count-filtered = '0') then attribute class { 'light-grey' } else() }{ $collection/@name/string() } ({ $count-filtered })</span>
+              <span class="light-grey"> ({ $count })</span>            
             </div>
             }
             <div class="confine-trigger-div" data-demoid="75603079-1b52-4ecd-91e5-1c4cd7221c7e">
               <input class="confine-trigger" type="submit" value="→"/>
             </div>
-             
+            
           </div>
         </div>
         <div data-demoid="bceb746e-7a77-4337-8e07-4f8b49e7388f" id="dcharter-preview-main">         


### PR DESCRIPTION
changes made in 2 collections: charters and search
in charters: the widget goto-search.widget.xml now points to search2
in search: search2 was refactored, different 'get' work-around in order to avoid too long urls.
Now user have to opt-in filters instead to opt them out. 
Only opt-in filters are submitted via rest.