### PR TITLE
bugfix search

### DIFF
--- a/my/XRX/src/mom/app/search/search.xqm
+++ b/my/XRX/src/mom/app/search/search.xqm
@@ -227,15 +227,10 @@ declare function search:sort-query-string() {
 
 
 
-(: compose the query string to be evaluated :)(: *** das trifft auf suche1 zu ***:)
+(: compose the query string to be evaluated :)
 declare function search:query-string($metadata-charter-db-base-collection-path) as xs:string {
 
-    concat(
-        if($xrx:tokenized-uri[last()] = 'search') then
-            search:scope-query-string($metadata-charter-db-base-collection-path)
-            
-        else
-            search:query-string-scope($metadata-charter-db-base-collection-path),
+    concat(search:query-string-scope($metadata-charter-db-base-collection-path),
         'for $charter in ',
         search:term-query-string(),
         search:img-query-string(),


### PR DESCRIPTION
Bei der Umstellung von search2 auf search wurde eine Ausnahme auf 'search' in search.xqm übersehen. Ausnahme wurde nun entfernt.