### PR TITLE
add `cei:hi` to `cei:archIdentifier` as it occurs often in RI

### DIFF
--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -2021,6 +2021,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:element ref="idno"/>
                     <xs:element ref="scope"/>
                     <xs:element ref="altIdentifier"/>
+                    <xs:element ref="hi"/>
                 </xs:choice>
             </xs:sequence>
             <xs:attributeGroup ref="lang"/>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -1916,6 +1916,7 @@
                     <xs:element ref="idno"/>
                     <xs:element ref="scope"/>
                     <xs:element ref="altIdentifier"/>
+                    <xs:element ref="hi"/>
                 </xs:choice>
             </xs:sequence>
             <xs:attributeGroup ref="lang"/>


### PR DESCRIPTION
To support import of Regesta Imperii