### PR TITLE
adjust schema for Fontenay import

### DIFF
--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -1,78 +1,64 @@
 <xs:schema xmlns="http://www.monasterium.net/NS/cei" xmlns:xerces="http://xerces.apache.org"
     xmlns:xrxe="http://www.monasterium.net/NS/xrxe" xmlns:xrx="http://www.monasterium.net/NS/xrx"
     xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified"
-    elementFormDefault="qualified" targetNamespace="http://www.monasterium.net/NS/cei" id="cei">
+    elementFormDefault="qualified" targetNamespace="http://www.monasterium.net/NS/cei" id="cei"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
     <xs:element name="cei">
         <xs:annotation>
-            <xs:documentation xml:lang="deu">
-Wurzelelement für alle Dokumente, die den Regeln der CEI (Charters Encoding
-Initiative, http://www.cei.lmu.de) folgen. CEI-Ableger mit Angaben
-zur EditMOM-Verarbeitung als appinfo und verringert auf ein
-Auszeichnungskonzept für Monasterium.net 2006-05-21 Änderungen: 2016-05-28: (lem|rdg)@wit eingeführt 2015-10-17: supplied hinzugefügt (GV) 
-2010-02-08: group:layout als Kind von abstract eingeführt
-2009-11-20: listBibl wieder eingeführt 2009-09-04: minOccurs="1" und
-maxOccurs="1" für Elemente "body/idno", "issued" und "date_sort" für
-Validierung beim Import eingeführt (JG) 2009-09-03: persName als
-Kind von persName eingeführt 2009-07-22: xs:group:Layout und
-Orignialbefund in dimensions, material, sealDesc, seal, legend,
-foreign, witness, arch eingefügt, um Siglen mit hochgestelleten
-Buchstaben aus Druckfassungen zuzulassen (GV) 2009-07-06:
-xs:attribute type in persName ergänzt 2008-05-28: xs:group ref=note
-in xs:element ref=note korrigiert 2008-05-19: divNote für
-Fußnotenblock eingeführt 2008-01-18: region und country neben
-Settlement ergänzt 2006-09-05: archFond, idno, scope: complex-type
-mixed 2006-09-01: num als Subelement zu date und dateRange
-eingeführt 2006-08-11: sealMaterial und sealCondition eingeführt;
-ein paar Aufräumarbeiten, legend in sealDesc eingebaut als
-Übergangslösung für Import aus Augias GV 2006-08-10: Gruppen:
-Formularium, RelevantPersonal getilgt, Referenz in Sachliches
-eingefügt; Standard-Attribute auf id und n reduziert, dafür rend nur
-noch bei hi, lang auf ausgewählte Elemente beschränkt (vgl.
-EditMOM), nota in "diplomaticAnalysis" eingefügt. measure
-mit num/index und Originalbefund versehen. GV 2006-08-09: seal,
-witness und alle Subelemente als globale Elemente definiert, den
-neuen globalen Elementen &lt;menu> vergeben (GV) 2006-07-06: pict zu
-group:Originalbefund hinzugefügt, NotariusSub auch als Teil von
-group:Formular eingefügt; issuer, recipient auch in der
-Transkription zulässig (GV) 2006-07-05: lang_MOM in mixed Type true
-umgewandelt (GV) 2006-06-27: verschiedene Attribut-Korrekturen (GV)
-2006-06-26: lang_MOM eingeführt. (GV) 2006-06-21: teiHeader
-fakultativ, respStmt aus text/front herausgenommen (GV) 2006-06-16:
-date_sort korrigiert, Attribut b_name zu &lt;text> eingeführt (GV)
-2006-06-07: issuer &amp; recipient nur in abstract zugelassen;
-subelemente von bibl entfernt; a global definiert, appinfo zu
-settlement, repository und scope global definiert. (GV) 2006-05-21:
-Captions geändert und ein paar Sicherheits &lt;present>no eingefügt.
-(GV) 2006-05-18: sourceDescVolltext ergänzt und kleinere
-editMOM-Ergänzungen (GV) 2006-05-17: sourceDesc aufgeräumt; Versuch
-alle Elemente, die in die Maske kommen, global zu definieren; note
-aus den Fließtexten geworfen. (GV) 2006-05-16: expan statt abbr für
-Abkürzung, note/index als eigener Reiter, &lt;caption
-xml:lang="deu"> eingefügt; Attribute (z.B. id/n) mit
-&lt;present>no&lt;/present> versehen. Menü
-"Siegelbeschreibung" ergänzt. &lt;sup> in p und abstract
-zugelassen, aber nicht in Menüs übernommen, denn diese Tags müssen
-noch nachbearbeitet werden. (GV) 2006-05-11 Einige Elemente, die in
-Fließtextfeldern auftauchen, global definiert (pTenor, a, legend),
-in einigen Fällen &lt;present>no&lt;/present> eingefügt (group etc.)
-(GV) 2006-05-09 Knoten, die selber nicht angezeigt werden und keine
-anzuzeigenden Subknoten haben, sind mit dem Attribut
-&lt;present>no&lt;/present> in der EditMOM-appinfo versehen. Alle
-Elemente, die als Fließtext auftauchen können, sind global
-definiert. (GV) 2006-05-02 listBibl (listBiblEdition,
-listBiblRegest, listBiblFaksimile, listBiblErw), sourceDesc
-(sourceDescRegest), p (p, pTenor) typisiert, um in der Anzeige
-differenzieren zu können. EditMOM:Auswahlliste eingeführt. (GV)
-2006-04-25 Weitere &lt;tab>-hinzugefügt. (GV) 2006-04-06 Innerhalb
-von hi Formular zugelassen; issuer verzweigt wie persName, persName
-kann auch note enthalten. Weitere Attributlisten plausibler
-aufgereiht. (GV) 2006-04-05 Reihenfolge der Tenorelemente plausibler
-angeordnet, hi::target in hi::type korrigiert, ein paar
-Attributlisten plausibler aufgereiht. (GV) 2006-03-28 p aus dem
-Originalbefund direkt unterhalb von tenor verschoben, um sachlich
-fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
-(Ausgangsversion)
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Wurzelelement für alle Dokumente, die den Regeln der
+                CEI (Charters Encoding Initiative, http://www.cei.lmu.de) folgen. CEI-Ableger mit
+                Angaben zur EditMOM-Verarbeitung als appinfo und verringert auf ein
+                Auszeichnungskonzept für Monasterium.net 2006-05-21 Änderungen: 2016-05-28:
+                (lem|rdg)@wit eingeführt 2015-10-17: supplied hinzugefügt (GV) 2010-02-08:
+                group:layout als Kind von abstract eingeführt 2009-11-20: listBibl wieder eingeführt
+                2009-09-04: minOccurs="1" und maxOccurs="1" für Elemente "body/idno", "issued" und
+                "date_sort" für Validierung beim Import eingeführt (JG) 2009-09-03: persName als
+                Kind von persName eingeführt 2009-07-22: xs:group:Layout und Orignialbefund in
+                dimensions, material, sealDesc, seal, legend, foreign, witness, arch eingefügt, um
+                Siglen mit hochgestelleten Buchstaben aus Druckfassungen zuzulassen (GV) 2009-07-06:
+                xs:attribute type in persName ergänzt 2008-05-28: xs:group ref=note in xs:element
+                ref=note korrigiert 2008-05-19: divNote für Fußnotenblock eingeführt 2008-01-18:
+                region und country neben Settlement ergänzt 2006-09-05: archFond, idno, scope:
+                complex-type mixed 2006-09-01: num als Subelement zu date und dateRange eingeführt
+                2006-08-11: sealMaterial und sealCondition eingeführt; ein paar Aufräumarbeiten,
+                legend in sealDesc eingebaut als Übergangslösung für Import aus Augias GV
+                2006-08-10: Gruppen: Formularium, RelevantPersonal getilgt, Referenz in Sachliches
+                eingefügt; Standard-Attribute auf id und n reduziert, dafür rend nur noch bei hi,
+                lang auf ausgewählte Elemente beschränkt (vgl. EditMOM), nota in
+                "diplomaticAnalysis" eingefügt. measure mit num/index und Originalbefund versehen.
+                GV 2006-08-09: seal, witness und alle Subelemente als globale Elemente definiert,
+                den neuen globalen Elementen &lt;menu> vergeben (GV) 2006-07-06: pict zu
+                group:Originalbefund hinzugefügt, NotariusSub auch als Teil von group:Formular
+                eingefügt; issuer, recipient auch in der Transkription zulässig (GV) 2006-07-05:
+                lang_MOM in mixed Type true umgewandelt (GV) 2006-06-27: verschiedene
+                Attribut-Korrekturen (GV) 2006-06-26: lang_MOM eingeführt. (GV) 2006-06-21:
+                teiHeader fakultativ, respStmt aus text/front herausgenommen (GV) 2006-06-16:
+                date_sort korrigiert, Attribut b_name zu &lt;text> eingeführt (GV) 2006-06-07:
+                issuer &amp; recipient nur in abstract zugelassen; subelemente von bibl entfernt; a
+                global definiert, appinfo zu settlement, repository und scope global definiert. (GV)
+                2006-05-21: Captions geändert und ein paar Sicherheits &lt;present>no eingefügt.
+                (GV) 2006-05-18: sourceDescVolltext ergänzt und kleinere editMOM-Ergänzungen (GV)
+                2006-05-17: sourceDesc aufgeräumt; Versuch alle Elemente, die in die Maske kommen,
+                global zu definieren; note aus den Fließtexten geworfen. (GV) 2006-05-16: expan
+                statt abbr für Abkürzung, note/index als eigener Reiter, &lt;caption xml:lang="deu">
+                eingefügt; Attribute (z.B. id/n) mit &lt;present>no&lt;/present> versehen. Menü
+                "Siegelbeschreibung" ergänzt. &lt;sup> in p und abstract zugelassen, aber nicht in
+                Menüs übernommen, denn diese Tags müssen noch nachbearbeitet werden. (GV) 2006-05-11
+                Einige Elemente, die in Fließtextfeldern auftauchen, global definiert (pTenor, a,
+                legend), in einigen Fällen &lt;present>no&lt;/present> eingefügt (group etc.) (GV)
+                2006-05-09 Knoten, die selber nicht angezeigt werden und keine anzuzeigenden
+                Subknoten haben, sind mit dem Attribut &lt;present>no&lt;/present> in der
+                EditMOM-appinfo versehen. Alle Elemente, die als Fließtext auftauchen können, sind
+                global definiert. (GV) 2006-05-02 listBibl (listBiblEdition, listBiblRegest,
+                listBiblFaksimile, listBiblErw), sourceDesc (sourceDescRegest), p (p, pTenor)
+                typisiert, um in der Anzeige differenzieren zu können. EditMOM:Auswahlliste
+                eingeführt. (GV) 2006-04-25 Weitere &lt;tab>-hinzugefügt. (GV) 2006-04-06 Innerhalb
+                von hi Formular zugelassen; issuer verzweigt wie persName, persName kann auch note
+                enthalten. Weitere Attributlisten plausibler aufgereiht. (GV) 2006-04-05 Reihenfolge
+                der Tenorelemente plausibler angeordnet, hi::target in hi::type korrigiert, ein paar
+                Attributlisten plausibler aufgereiht. (GV) 2006-03-28 p aus dem Originalbefund
+                direkt unterhalb von tenor verschoben, um sachlich fehlerhafte Rekursionen zu
+                vermeiden (GV) 2006-03-19 (Ausgangsversion) </xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
@@ -105,12 +91,12 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                         <xs:element name="titleStmt">
                                             <xs:annotation>
                                                 <xs:appinfo source="EditVDU">
-                                                    <xrxe:label>
-                                                        <xrx:i18n>
-                                                            <xrx:key>cei_titleStmt</xrx:key>
-                                                            <xrx:default>titleStmt</xrx:default>
-                                                        </xrx:i18n>
-                                                    </xrxe:label>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_titleStmt</xrx:key>
+                                                  <xrx:default>titleStmt</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
                                                 </xs:appinfo>
                                                 <xs:documentation xml:lang="deu"> Den Regeln der TEI
                                                   entsprechend müßten hier verschiedene Elemente
@@ -124,14 +110,14 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                                   <xs:element name="author">
                                                   <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
-                                                                    <xrxe:label>
-                                                                        <xrx:i18n>
-                                                                            <xrx:key>cei_author</xrx:key>
-                                                                            <xrx:default>author</xrx:default>
-                                                                        </xrx:i18n>
-                                                                    </xrxe:label>
-                                                                    <xrxe:relevant>false</xrxe:relevant>
-                                                                </xs:appinfo>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_author</xrx:key>
+                                                  <xrx:default>author</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
+                                                  <xrxe:relevant>false</xrxe:relevant>
+                                                  </xs:appinfo>
                                                   </xs:annotation>
                                                   </xs:element>
                                                   <xs:element ref="p"/>
@@ -144,13 +130,13 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                         <xs:element minOccurs="0" name="sourceDesc">
                                             <xs:annotation>
                                                 <xs:appinfo source="EditVDU">
-                                                    <xrxe:label>
-                                                        <xrx:i18n>
-                                                            <xrx:key>cei_sourceDesc</xrx:key>
-                                                            <xrx:default>sourceDesc</xrx:default>
-                                                        </xrx:i18n>
-                                                    </xrxe:label>
-                                                    <xrxe:relevant>false</xrxe:relevant>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_sourceDesc</xrx:key>
+                                                  <xrx:default>sourceDesc</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
+                                                  <xrxe:relevant>false</xrxe:relevant>
                                                 </xs:appinfo>
                                                 <xs:documentation xml:lang="deu"> enthält die
                                                   bibliographischen Angaben der Quellen, aus denen
@@ -219,9 +205,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:relevant>false</xrxe:relevant>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Formale Regeln, die bei der Codierung angewendet worden sind.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Formale Regeln, die bei der Codierung angewendet
+                worden sind. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:complexContent mixed="true">
@@ -242,9 +227,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:relevant>false</xrxe:relevant>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Angaben zur Veröffentlichung des Textes (Zeitpunkt, rechtsverbindlicher
-        Ort, Beschränkungen, Verantwortlichkeiten ...)
+            <xs:documentation xml:lang="deu"> Angaben zur Veröffentlichung des Textes (Zeitpunkt,
+                rechtsverbindlicher Ort, Beschränkungen, Verantwortlichkeiten ...)
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -332,9 +316,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:relevant>false</xrxe:relevant>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Angaben über die inhaltliche, redaktionelle und verlegerische Verantwortung
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Angaben über die inhaltliche, redaktionelle und
+                verlegerische Verantwortung </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -351,12 +334,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                 </xrxe:label>
                                 <xrxe:relevant>false</xrxe:relevant>
                             </xs:appinfo>
-                            <xs:documentation xml:lang="deu">
-                beschreibt die intellektuelle Verantwortlichkeit einer Person
-              </xs:documentation>
-                            <xs:documentation xml:lang="eng">
-                contains a phrase describing the nature of a person's intellectual
-                responsibility.
+                            <xs:documentation xml:lang="deu"> beschreibt die intellektuelle
+                                Verantwortlichkeit einer Person </xs:documentation>
+                            <xs:documentation xml:lang="eng"> contains a phrase describing the
+                                nature of a person's intellectual responsibility.
                             </xs:documentation>
                         </xs:annotation>
                         <xs:complexType>
@@ -385,10 +366,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:mixed>false</xrxe:mixed>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Mit type="charter" als Urkunde identifiziert; type="collection" faßt
-        einen Bestand zusammen. Textelemente:
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Mit type="charter" als Urkunde identifiziert;
+                type="collection" faßt einen Bestand zusammen. Textelemente: </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice>
@@ -399,9 +378,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                 <xrxe:label/>
                                 <xrxe:mixed>false</xrxe:mixed>
                             </xs:appinfo>
-                            <xs:documentation xml:lang="deu">
-                Der Vorspann zu einem Text (Titelblatt, Vorwort,
-                Inhaltsverzeichnis, Danksagung etc.)
+                            <xs:documentation xml:lang="deu"> Der Vorspann zu einem Text
+                                (Titelblatt, Vorwort, Inhaltsverzeichnis, Danksagung etc.)
                             </xs:documentation>
                         </xs:annotation>
                         <xs:complexType mixed="true">
@@ -411,10 +389,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_sourceDesc</xrx:key>
-                                                        <xrx:default>sourceDesc</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_sourceDesc</xrx:key>
+                                                  <xrx:default>sourceDesc</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                             </xs:appinfo>
                                         </xs:annotation>
@@ -424,31 +402,32 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                                   <xs:element name="sourceDescRegest">
                                                   <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
-                                                                <xrxe:label>
-                                                                    <xrx:i18n>
-                                                                        <xrx:key>cei_sourceDescRegest</xrx:key>
-                                                                        <xrx:default>sourceDescRegest</xrx:default>
-                                                                    </xrx:i18n>
-                                                                </xrxe:label>
-                                                            </xs:appinfo>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_sourceDescRegest</xrx:key>
+                                                  <xrx:default>sourceDescRegest</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
+                                                  </xs:appinfo>
                                                   <xs:documentation xml:lang="deu">
-                                CEI_MOM-spezifisch: Eigentlich eine SourceDesc, die über
-                                ein Schlüsselwort "Regest" auf die Quelle des Regests
-                                verweist.
-                                                            </xs:documentation>
+                                                  CEI_MOM-spezifisch: Eigentlich eine SourceDesc,
+                                                  die über ein Schlüsselwort "Regest" auf die Quelle
+                                                  des Regests verweist. </xs:documentation>
                                                   </xs:annotation>
                                                   <xs:complexType>
                                                   <xs:sequence>
                                                   <xs:element maxOccurs="unbounded" ref="bibl">
                                                   <xs:annotation>
-                                                  <xs:documentation xml:lang="deu">Gibt die
-                                      Quelle für das Regest an.</xs:documentation>
+                                                  <xs:documentation xml:lang="deu">Gibt die Quelle
+                                                  für das Regest an.</xs:documentation>
                                                   </xs:annotation>
                                                   </xs:element>
                                                   </xs:sequence>
                                                   <xs:attribute name="ref">
                                                   <xs:annotation>
-                                                  <xs:documentation xml:lang="deu">Verweis auf eine Textpassage, zu der hier die Quelle angegeben wird.</xs:documentation>
+                                                  <xs:documentation xml:lang="deu">Verweis auf eine
+                                                  Textpassage, zu der hier die Quelle angegeben
+                                                  wird.</xs:documentation>
                                                   </xs:annotation>
                                                   </xs:attribute>
                                                   <xs:attributeGroup ref="standard"/>
@@ -457,35 +436,32 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                                   <xs:element name="sourceDescVolltext">
                                                   <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
-                                                                <xrxe:label>
-                                                                    <xrx:i18n>
-                                                                        <xrx:key>cei_sourceDescVolltext</xrx:key>
-                                                                        <xrx:default>sourceDescVolltext</xrx:default>
-                                                                    </xrx:i18n>
-                                                                </xrxe:label>
-                                                            </xs:appinfo>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_sourceDescVolltext</xrx:key>
+                                                  <xrx:default>sourceDescVolltext</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
+                                                  </xs:appinfo>
                                                   <xs:documentation xml:lang="deu">
-                                CEI_MOM-spezifisch: Eigentlich eine SourceDesc, die über
-                                ein Schlüsselwort "Volltext" auf die Quelle des Regests
-                                verweist.
-                                                            </xs:documentation>
+                                                  CEI_MOM-spezifisch: Eigentlich eine SourceDesc,
+                                                  die über ein Schlüsselwort "Volltext" auf die
+                                                  Quelle des Regests verweist. </xs:documentation>
                                                   </xs:annotation>
                                                   <xs:complexType>
                                                   <xs:sequence>
                                                   <xs:element maxOccurs="unbounded" ref="bibl">
                                                   <xs:annotation>
-                                                  <xs:documentation xml:lang="deu">Gibt die
-                                      Quelle für den Volltext an.
-                                                                        </xs:documentation>
+                                                  <xs:documentation xml:lang="deu">Gibt die Quelle
+                                                  für den Volltext an. </xs:documentation>
                                                   </xs:annotation>
                                                   </xs:element>
                                                   </xs:sequence>
                                                   <xs:attribute name="ref">
                                                   <xs:annotation>
-                                                  <xs:documentation xml:lang="deu">
-                                    Verweis auf eine Textpassage, zu der hier die Quelle
-                                    angegeben wird.
-                                  </xs:documentation>
+                                                  <xs:documentation xml:lang="deu"> Verweis auf eine
+                                                  Textpassage, zu der hier die Quelle angegeben
+                                                  wird. </xs:documentation>
                                                   </xs:annotation>
                                                   </xs:attribute>
                                                   <xs:attributeGroup ref="standard"/>
@@ -494,8 +470,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                                   <xs:element ref="p">
                                                   <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
-                                                                <xrxe:relevant>false</xrxe:relevant>
-                                                            </xs:appinfo>
+                                                  <xrxe:relevant>false</xrxe:relevant>
+                                                  </xs:appinfo>
                                                   </xs:annotation>
                                                   </xs:element>
                                                 </xs:choice>
@@ -536,17 +512,17 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                         <xs:element minOccurs="1" maxOccurs="1" name="idno">
                                             <xs:annotation>
                                                 <xs:appinfo source="EditVDU">
-                                                    <xrxe:label>
-                                                        <xrx:i18n>
-                                                            <xrx:key>cei_idno</xrx:key>
-                                                            <xrx:default>idno</xrx:default>
-                                                        </xrx:i18n>
-                                                    </xrxe:label>
-                                                    <xrxe:relevant>false</xrxe:relevant>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_idno</xrx:key>
+                                                  <xrx:default>idno</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
+                                                  <xrxe:relevant>false</xrxe:relevant>
                                                 </xs:appinfo>
-                                                <xs:documentation xml:lang="deu">
-                          Gibt die Identifikationsnummer der Urkunde im aktuellen Corpus an.
-                                                </xs:documentation>
+                                                <xs:documentation xml:lang="deu"> Gibt die
+                                                  Identifikationsnummer der Urkunde im aktuellen
+                                                  Corpus an. </xs:documentation>
                                             </xs:annotation>
                                             <xs:complexType>
                                                 <xs:simpleContent>
@@ -586,9 +562,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                     </xrxe:label>
                                     <xrxe:relevant>false</xrxe:relevant>
                                 </xs:appinfo>
-                                <xs:documentation xml:lang="deu">
-                  Eine Gruppe von eigenständigen Texten als Teil eines Corpus z.B.
-                </xs:documentation>
+                                <xs:documentation xml:lang="deu"> Eine Gruppe von eigenständigen
+                                    Texten als Teil eines Corpus z.B. </xs:documentation>
                             </xs:annotation>
                             <xs:complexType>
                                 <xs:sequence>
@@ -606,9 +581,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                             <xs:appinfo source="EditVDU">
                                 <xrxe:label/>
                             </xs:appinfo>
-                            <xs:documentation xml:lang="deu">
-                Anhänge zu einem Text (z.B. Endnoten, Register, Verzeichnisse)
-              </xs:documentation>
+                            <xs:documentation xml:lang="deu"> Anhänge zu einem Text (z.B. Endnoten,
+                                Register, Verzeichnisse) </xs:documentation>
                         </xs:annotation>
                         <xs:complexType>
                             <xs:sequence>
@@ -673,13 +647,14 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xs:element>
                 </xs:sequence>
             </xs:choice>
-            <xs:attribute name="type"/>
+            <xs:attribute name="type" use="required"/> <!--Erweiterung-->
             <xs:attributeGroup ref="picture"/>
             <xs:attributeGroup ref="certainty"/>
             <xs:attributeGroup ref="standard"/>
             <xs:attribute name="b_name" type="xs:anySimpleType">
                 <xs:annotation>
-                    <xs:documentation xml:lang="deu">MOM-spezifisch! Enthält noch mal den Bestandsname.</xs:documentation>
+                    <xs:documentation xml:lang="deu">MOM-spezifisch! Enthält noch mal den
+                        Bestandsname.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
         </xs:complexType>
@@ -695,11 +670,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:relevant>false</xrxe:relevant>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Die Identifikationsnummer eines Objektes innerhalb der aktuellen
-        Struktur (z.B. Nummer in einem Urkundenbuch, Bestand in einem
-        Archiv, Handschriftensignatur in einer Bibliothek.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Die Identifikationsnummer eines Objektes innerhalb der
+                aktuellen Struktur (z.B. Nummer in einem Urkundenbuch, Bestand in einem Archiv,
+                Handschriftensignatur in einer Bibliothek. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence minOccurs="0" maxOccurs="unbounded">
@@ -722,10 +695,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:mixed>false</xrxe:mixed>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Faßt die Metadaten einer Urkunde zusammen. Metadatenelemente
-      </xs:documentation>
-            <xs:documentation xml:lang="eng">contains the meta-data for the charter</xs:documentation>
+            <xs:documentation xml:lang="deu"> Faßt die Metadaten einer Urkunde zusammen.
+                Metadatenelemente </xs:documentation>
+            <xs:documentation xml:lang="eng">contains the meta-data for the
+                charter</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -743,12 +716,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                 </xrxe:label>
                                 <xrxe:mixed>false</xrxe:mixed>
                             </xs:appinfo>
-                            <xs:documentation xml:lang="deu">
-                Diese Konstruktion kann allgemeine Elemente für die Beschreibung von
-                Ausstellungsort und -zeit verwenden und ist deshalb den
-                Konstrukten "issuePlace" und "date" bzw. "publicationStmt"
-                vorzuziehen. [strict!]
-                            </xs:documentation>
+                            <xs:documentation xml:lang="deu"> Diese Konstruktion kann allgemeine
+                                Elemente für die Beschreibung von Ausstellungsort und -zeit
+                                verwenden und ist deshalb den Konstrukten "issuePlace" und "date"
+                                bzw. "publicationStmt" vorzuziehen. [strict!] </xs:documentation>
                         </xs:annotation>
                         <xs:complexType mixed="true">
                             <xs:annotation>
@@ -770,30 +741,33 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                         <xs:element ref="date">
                                             <xs:annotation>
                                                 <xs:appinfo source="EditVDU">
-                                                    <xrxe:min-occur>0</xrxe:min-occur>
-                                                    <xrxe:max-occur>1</xrxe:max-occur>
+                                                  <xrxe:min-occur>0</xrxe:min-occur>
+                                                  <xrxe:max-occur>1</xrxe:max-occur>
                                                 </xs:appinfo>
                                                 <xs:documentation>
-                                                    <xrx:description>
-                                                        <xrx:i18n>
-                                                            <xrx:key>cei_issued_date_description</xrx:key>
-                                                            <xrx:default>Datum, an dem die Urkunde ausgestellt ist. Die Daten werden im Format 'Jahr Monat (als Wort) Tag' angegeben.</xrx:default>
-                                                        </xrx:i18n>
-                                                    </xrx:description>
-                                                    <xrx:example>
-                                                        <xrx:i18n>
-                                                            <xrx:key>cei_issued_date_example</xrx:key>
-                                                            <xrx:default>&lt;cei:date value="16091001">1609 Oktober 1&lt;/cei:date></xrx:default>
-                                                        </xrx:i18n>
-                                                    </xrx:example>
+                                                  <xrx:description>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_issued_date_description</xrx:key>
+                                                  <xrx:default>Datum, an dem die Urkunde ausgestellt
+                                                  ist. Die Daten werden im Format 'Jahr Monat (als
+                                                  Wort) Tag' angegeben.</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrx:description>
+                                                  <xrx:example>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_issued_date_example</xrx:key>
+                                                  <xrx:default>&lt;cei:date value="16091001">1609
+                                                  Oktober 1&lt;/cei:date></xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrx:example>
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element ref="dateRange">
                                             <xs:annotation>
                                                 <xs:appinfo source="EditVDU">
-                                                    <xrxe:min-occur>0</xrxe:min-occur>
-                                                    <xrxe:max-occur>1</xrxe:max-occur>
+                                                  <xrxe:min-occur>0</xrxe:min-occur>
+                                                  <xrxe:max-occur>1</xrxe:max-occur>
                                                 </xs:appinfo>
                                             </xs:annotation>
                                         </xs:element>
@@ -809,7 +783,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                     <xs:appinfo>
                                         <xrx:i18n>
                                             <xrx:key>wrong-date-format-message</xrx:key>
-                                            <xrx:default>Wrong date format. YYYYMMDD is expected.</xrx:default>
+                                            <xrx:default>Wrong date format. YYYYMMDD is
+                                                expected.</xrx:default>
                                         </xrx:i18n>
                                     </xs:appinfo>
                                 </xs:annotation>
@@ -822,7 +797,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                     <xs:appinfo>
                                         <xrx:i18n>
                                             <xrx:key>wrong-date-format-message</xrx:key>
-                                            <xrx:default>Wrong date format. YYYYMMDD is expected.</xrx:default>
+                                            <xrx:default>Wrong date format. YYYYMMDD is
+                                                expected.</xrx:default>
                                         </xrx:i18n>
                                     </xs:appinfo>
                                 </xs:annotation>
@@ -835,7 +811,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                     <xs:appinfo>
                                         <xrx:i18n>
                                             <xrx:key>wrong-date-format-message</xrx:key>
-                                            <xrx:default>Wrong date format. YYYYMMDD is expected.</xrx:default>
+                                            <xrx:default>Wrong date format. YYYYMMDD is
+                                                expected.</xrx:default>
                                         </xrx:i18n>
                                     </xs:appinfo>
                                 </xs:annotation>
@@ -844,7 +821,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xs:element>
                     <xs:element name="witnessOrig">
                         <xs:annotation>
-                            <xs:documentation xml:lang="deu">Der einzelne Textzeuge (MOM)</xs:documentation>
+                            <xs:documentation xml:lang="deu">Der einzelne Textzeuge
+                                (MOM)</xs:documentation>
                             <xs:appinfo source="EditVDU">
                                 <xrxe:label>
                                     <xrx:i18n>
@@ -880,16 +858,17 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                             </xs:appinfo>
                                         </xs:annotation>
                                     </xs:element>
+                                    <xs:element ref="p"/>
+                                    <!--Erweiterung-->
                                 </xs:choice>
                             </xs:sequence>
                             <xs:attributeGroup ref="certainty"/>
                             <xs:attribute name="type" type="xs:anySimpleType" use="optional"/>
                             <xs:attribute name="sigil" type="xs:anySimpleType">
                                 <xs:annotation>
-                                    <xs:documentation xml:lang="deu">
-                    P5 sieht dafür das Attribut id vor. Diese Lösung ist sowohl dem
-                    Element, als auch dem Attribut vorzuziehen. [strict!]
-                  </xs:documentation>
+                                    <xs:documentation xml:lang="deu"> P5 sieht dafür das Attribut id
+                                        vor. Diese Lösung ist sowohl dem Element, als auch dem
+                                        Attribut vorzuziehen. [strict!] </xs:documentation>
                                 </xs:annotation>
                             </xs:attribute>
                             <xs:attribute name="sameAs" type="xs:anySimpleType" use="optional"/>
@@ -908,14 +887,11 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                 </xrxe:label>
                                 <xrxe:mixed>false</xrxe:mixed>
                             </xs:appinfo>
-                            <xs:documentation xml:lang="deu">
-                Enthält Bemerkungen zur diplomatischen Kritik der Urkunde, die formale
-                Beobachtungen der inneren wie äußeren Merkmale ebenso wie
-                inhaltliche Überlegungen enthalten kann.
-                            </xs:documentation>
-                            <xs:documentation xml:lang="eng">
-                contains a diplomatic analysis of the document, formal critics or
-                critics by the content.
+                            <xs:documentation xml:lang="deu"> Enthält Bemerkungen zur diplomatischen
+                                Kritik der Urkunde, die formale Beobachtungen der inneren wie
+                                äußeren Merkmale ebenso wie inhaltliche Überlegungen enthalten kann. </xs:documentation>
+                            <xs:documentation xml:lang="eng"> contains a diplomatic analysis of the
+                                document, formal critics or critics by the content.
                             </xs:documentation>
                         </xs:annotation>
                         <xs:complexType mixed="true">
@@ -925,17 +901,16 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_listBibl</xrx:key>
-                                                        <xrx:default>listBibl</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_listBibl</xrx:key>
+                                                  <xrx:default>listBibl</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                                 <xrxe:mixed>false</xrxe:mixed>
                                             </xs:appinfo>
-                                            <xs:documentation xml:lang="deu">
-                        undifferenzierte Bibliographische Auflistung von Titeln, die die Urkunde
-                        betreffen..
-                                            </xs:documentation>
+                                            <xs:documentation xml:lang="deu"> undifferenzierte
+                                                Bibliographische Auflistung von Titeln, die die
+                                                Urkunde betreffen.. </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
                                             <xs:sequence>
@@ -946,6 +921,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                                   </xs:choice>
                                                 </xs:choice>
                                             </xs:sequence>
+                                            <xs:attribute name="type"/>
+                                            <!--Erweiterung-->
                                             <xs:attributeGroup ref="standard"/>
                                         </xs:complexType>
                                     </xs:element>
@@ -953,16 +930,16 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_listBiblEdition</xrx:key>
-                                                        <xrx:default>listBiblEdition</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_listBiblEdition</xrx:key>
+                                                  <xrx:default>listBiblEdition</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                                 <xrxe:mixed>false</xrxe:mixed>
                                             </xs:appinfo>
-                                            <xs:documentation xml:lang="deu">
-                        Bibliographische Auflistung der Editionen = listBibl type="print".
-                      </xs:documentation>
+                                            <xs:documentation xml:lang="deu"> Bibliographische
+                                                Auflistung der Editionen = listBibl type="print".
+                                            </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
                                             <xs:sequence>
@@ -980,15 +957,15 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_listBiblRegest</xrx:key>
-                                                        <xrx:default>listBiblRegest</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_listBiblRegest</xrx:key>
+                                                  <xrx:default>listBiblRegest</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                                 <xrxe:mixed>false</xrxe:mixed>
                                             </xs:appinfo>
-                                            <xs:documentation xml:lang="deu">
-                        Bibliographische Auflistungen = listBibl type="regesta".
+                                            <xs:documentation xml:lang="deu"> Bibliographische
+                                                Auflistungen = listBibl type="regesta".
                                             </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
@@ -1007,16 +984,16 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_listBiblFaksimile</xrx:key>
-                                                        <xrx:default>listBiblFaksimile</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_listBiblFaksimile</xrx:key>
+                                                  <xrx:default>listBiblFaksimile</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                                 <xrxe:mixed>false</xrxe:mixed>
                                             </xs:appinfo>
-                                            <xs:documentation xml:lang="deu">
-                        Bibliographische Auflistung der Faksimiles = listBibl type="facsimilia"
-                      </xs:documentation>
+                                            <xs:documentation xml:lang="deu"> Bibliographische
+                                                Auflistung der Faksimiles = listBibl
+                                                type="facsimilia" </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
                                             <xs:sequence>
@@ -1034,16 +1011,16 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_listBiblErw</xrx:key>
-                                                        <xrx:default>listBiblErw</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_listBiblErw</xrx:key>
+                                                  <xrx:default>listBiblErw</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                                 <xrxe:mixed>false</xrxe:mixed>
                                             </xs:appinfo>
-                                            <xs:documentation xml:lang="deu">
-                        Bibliographische Auflistung der Erwähnungen = listBibl type="studies"
-                      </xs:documentation>
+                                            <xs:documentation xml:lang="deu"> Bibliographische
+                                                Auflistung der Erwähnungen = listBibl type="studies"
+                                            </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
                                             <xs:sequence>
@@ -1088,9 +1065,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                 <xrxe:mixed>false</xrxe:mixed>
                                 <xrxe:control-control>input</xrxe:control-control>
                             </xs:appinfo>
-                            <xs:documentation>
-                                MOM-spezifisch: Eigentlich tenor@lang
-              </xs:documentation>
+                            <xs:documentation> MOM-spezifisch: Eigentlich tenor@lang
+                            </xs:documentation>
                         </xs:annotation>
                         <xs:complexType mixed="true">
                             <xs:attributeGroup ref="standard"/>
@@ -1117,13 +1093,21 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrx:description>
                     <xrx:i18n>
                         <xrx:key>cei_abstract_description</xrx:key>
-                        <xrx:default>Abstract which summarizes the legal contents of a charter document; either a short header in some editions or a more detailed long-abstract with verbatim citations. Note: All abstracts must name the author/sender of a document and should mention its receiver.</xrx:default>
+                        <xrx:default>Abstract which summarizes the legal contents of a charter
+                            document; either a short header in some editions or a more detailed
+                            long-abstract with verbatim citations. Note: All abstracts must name the
+                            author/sender of a document and should mention its
+                            receiver.</xrx:default>
                     </xrx:i18n>
                 </xrx:description>
                 <xrx:example>
                     <xrx:i18n>
                         <xrx:key>cei_abstract_example</xrx:key>
-                        <xrx:default>&lt;cei:abstract>&lt;cei:issuer>Rudolph III. Herzog von Österreich&lt;/cei:issuer> bestätigt die Privilegien des &lt;cei:recipient>Klosters Geras&lt;/cei:recipient>, namentlich in gewissen Beziehungen, in denen Beeinträchtigungen eingetreten waren.&lt;/cei:abstract></xrx:default>
+                        <xrx:default>&lt;cei:abstract>&lt;cei:issuer>Rudolph III. Herzog von
+                            Österreich&lt;/cei:issuer> bestätigt die Privilegien des
+                            &lt;cei:recipient>Klosters Geras&lt;/cei:recipient>, namentlich in
+                            gewissen Beziehungen, in denen Beeinträchtigungen eingetreten
+                            waren.&lt;/cei:abstract></xrx:default>
                     </xrx:i18n>
                 </xrx:example>
             </xs:documentation>
@@ -1155,9 +1139,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
                 <xrxe:relevant>false</xrxe:relevant>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-                Referenz auf ein Bild
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Referenz auf ein Bild </xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
@@ -1271,7 +1253,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="en">add complex text to a tagged part of the document.</xs:documentation>
+            <xs:documentation xml:lang="en">add complex text to a tagged part of the
+                document.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:attributeGroup ref="lang"/>
@@ -1279,6 +1262,46 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
             <xs:attributeGroup ref="resp"/>
         </xs:complexType>
     </xs:element>
+    <!--Erweiterung-Anfang-->
+    <xs:element name="w">
+        <xs:annotation>
+            <xs:documentation xml:lang="deu">Wort-Element für Transkription.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType mixed="true">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="expan"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="hi"/>
+                <xs:element ref="sic"/>
+                <xs:element ref="seg"/>
+                <xs:element ref="space"/>
+            </xs:choice>
+            <xs:attribute name="id"/>
+            <xs:attribute name="note"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="pc">
+        <xs:annotation>
+            <xs:documentation xml:lang="deu">Satzzeichen-Element für
+                Tranksription.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType mixed="true">
+            <xs:attribute name="id"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="seg">
+        <xs:complexType mixed="true">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="expan"/>
+                <xs:element ref="hi"/>
+                <xs:element ref="damage"/>
+            </xs:choice>
+            <xs:attribute name="type"/>
+            <xs:attribute name="id"/>
+            <xs:attribute name="part"/>
+        </xs:complexType>
+    </xs:element>
+    <!--Erweiterung-Ende-->
     <xs:element name="witListPar">
         <xs:annotation>
             <xs:appinfo source="EditVDU">
@@ -1290,8 +1313,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:mixed>false</xrxe:mixed>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">       
-                Textzeugen: kopiale Überlieferung (MOM)
+            <xs:documentation xml:lang="deu"> Textzeugen: kopiale Überlieferung (MOM)
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -1317,9 +1339,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
                 <xrxe:mixed>false</xrxe:mixed>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-                Der einzelne Textzeuge
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Der einzelne Textzeuge </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -1372,11 +1392,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:min-occur>0</xrxe:min-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Überlieferungsform: Original, Kopial, Insert, Transsumpt, Vidimus, Konzept. Die
-        verwendete Begrifflichkeit ist dem VID zu entnehmen oder in der
-        profileDesc zu dokumentieren.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Überlieferungsform: Original, Kopial, Insert,
+                Transsumpt, Vidimus, Konzept. Die verwendete Begrifflichkeit ist dem VID zu
+                entnehmen oder in der profileDesc zu dokumentieren. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence minOccurs="0" maxOccurs="unbounded">
@@ -1444,12 +1462,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:mixed>false</xrxe:mixed>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        beschreibt die Mittel zur Beglaubigung der Urkunde (Siegel,
-        Notarsunterschriften etc.)
-            </xs:documentation>
-            <xs:documentation xml:lang="eng">describes the
-        authentification of the document.
+            <xs:documentation xml:lang="deu"> beschreibt die Mittel zur Beglaubigung der Urkunde
+                (Siegel, Notarsunterschriften etc.) </xs:documentation>
+            <xs:documentation xml:lang="eng">describes the authentification of the document.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -1478,8 +1493,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:content-control>annotation</xrxe:content-control>
                 <xrxe:rows>5</xrxe:rows>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-                eine differenzierte Siegelbeschreibung.
+            <xs:documentation xml:lang="deu"> eine differenzierte Siegelbeschreibung.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -1513,8 +1527,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-                Ein einzelnes Siegel (CEI_MOM spezifisch!)
+            <xs:documentation xml:lang="deu"> Ein einzelnes Siegel (CEI_MOM spezifisch!)
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -1551,9 +1564,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        gibt den Text, der auf einem Siegel angebracht ist, wieder.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> gibt den Text, der auf einem Siegel angebracht ist,
+                wieder. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -1584,9 +1596,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-                der Siegelinhaber
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> der Siegelinhaber </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -1611,8 +1621,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:content-control>annotation</xrxe:content-control>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Beschreibung einer
-        notariellen Unterfertigung.</xs:documentation>
+            <xs:documentation xml:lang="deu">Beschreibung einer notariellen
+                Unterfertigung.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -1629,9 +1639,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:element ref="persName"/>
                     <xs:choice>
                         <xs:annotation>
-                            <xs:documentation xml:lang="deu">
-                                Geographische Angaben
-              </xs:documentation>
+                            <xs:documentation xml:lang="deu"> Geographische Angaben
+                            </xs:documentation>
                         </xs:annotation>
                         <xs:element ref="placeName"/>
                         <xs:element ref="geogName"/>
@@ -1659,7 +1668,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:relevant>true</xrxe:relevant>
             </xs:appinfo>
             <xs:documentation xml:lang="de">Teilurkundenschnitt</xs:documentation>
-            <xs:documentation xml:lang="en">contains a description of the method how a chirograph (cfr. VID 44, http://www.cei.lmu.de/VID/#VID_44) is executed, e.g. the text written in the place of cutting, and/or the form of the cutting.</xs:documentation>
+            <xs:documentation xml:lang="en">contains a description of the method how a chirograph
+                (cfr. VID 44, http://www.cei.lmu.de/VID/#VID_44) is executed, e.g. the text written
+                in the place of cutting, and/or the form of the cutting.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence minOccurs="0" maxOccurs="unbounded">
@@ -1683,10 +1694,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:content-control>annotation</xrxe:content-control>
                 <xrxe:relevant>true</xrxe:relevant>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu"> Enthält Vermerke des verwahrenden Archivs oder des Empfängers auf der
-                Urkunde.</xs:documentation>
-            <xs:documentation xml:lang="eng">contains notes on the document applied by the preserving archives or the recipient.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Enthält Vermerke des verwahrenden Archivs oder des
+                Empfängers auf der Urkunde.</xs:documentation>
+            <xs:documentation xml:lang="eng">contains notes on the document applied by the
+                preserving archives or the recipient. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -1715,8 +1726,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:content-control>annotation</xrxe:content-control>
                 <xrxe:relevant>false</xrxe:relevant>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Enthält die ersten Wörter des Textes. Im Attribute "type" wird angegeben, auf welchen Textteil es sich bezieht,</xs:documentation>
-            <xs:documentation xml:lang="eng">contains the first words of the text. The attribute "type" specifies if it refers to specific part of the text.</xs:documentation>
+            <xs:documentation xml:lang="deu">Enthält die ersten Wörter des Textes. Im Attribute
+                "type" wird angegeben, auf welchen Textteil es sich bezieht,</xs:documentation>
+            <xs:documentation xml:lang="eng">contains the first words of the text. The attribute
+                "type" specifies if it refers to specific part of the text.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -1741,11 +1754,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:mixed>false</xrxe:mixed>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        beschreibt die physikalischen Merkmale des Textzeugen, als Freitext erfaßt
-        werden können oder weitere Strukturen haben können wie
-        Beschreibstoff (material), Maße (dimensions) etc.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> beschreibt die physikalischen Merkmale des Textzeugen,
+                als Freitext erfaßt werden können oder weitere Strukturen haben können wie
+                Beschreibstoff (material), Maße (dimensions) etc. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -1795,9 +1806,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:content-control>annotation</xrxe:content-control>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Maße des Objekts (Höhe x Breite oder in eigenen Elementen)
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Maße des Objekts (Höhe x Breite oder in eigenen
+                Elementen) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence minOccurs="0" maxOccurs="unbounded">
@@ -1854,14 +1864,17 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                     </xrx:i18n>
                                 </xrxe:menu-item>
                             </xs:appinfo>
-                            <xs:documentation xml:lang="eng">
-                                describes the depth of the fold used to secure the threads for the seal
-                            </xs:documentation>
+                            <xs:documentation xml:lang="eng"> describes the depth of the fold used
+                                to secure the threads for the seal </xs:documentation>
                         </xs:annotation>
                     </xs:element>
                 </xs:choice>
             </xs:sequence>
             <xs:attributeGroup ref="standard"/>
+            <xs:attribute name="type" type="xs:string"/>
+            <!--Erweiterung-->
+            <xs:attribute name="unit" type="xs:string"/>
+            <!--Erweiterung-->
         </xs:complexType>
     </xs:element>
     <xs:element name="sealDimensions">
@@ -1882,9 +1895,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Maße des Objekts (Höhe x Breite oder in eigenen Elementen)
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Maße des Objekts (Höhe x Breite oder in eigenen
+                Elementen) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:attributeGroup ref="standard"/>
@@ -1902,12 +1914,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:content-control>annotation</xrxe:content-control>
                 <xrxe:min-occur>0</xrxe:min-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Stoff des beschriebenen Objekts (Beschreibstoff, Siegelmaterial)
-      </xs:documentation>
-            <xs:documentation xml:lang="eng">
-        describes the material on which the document is written
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Stoff des beschriebenen Objekts (Beschreibstoff,
+                Siegelmaterial) </xs:documentation>
+            <xs:documentation xml:lang="eng"> describes the material on which the document is
+                written </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence minOccurs="0" maxOccurs="unbounded">
@@ -1938,12 +1948,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Stoff des beschriebenen Objekts (Beschreibstoff, Siegelmaterial)
-      </xs:documentation>
-            <xs:documentation xml:lang="eng">
-        describes the material on which the document is written
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Stoff des beschriebenen Objekts (Beschreibstoff,
+                Siegelmaterial) </xs:documentation>
+            <xs:documentation xml:lang="eng"> describes the material on which the document is
+                written </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:attributeGroup ref="lang"/>
@@ -1963,12 +1971,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
                 <xrxe:content-control>annotation</xrxe:content-control>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Enthält Vermerke der ausstellenden Kanzlei auf der Urkunde. Für
-        Archivvermerke beim Empfänger vgl. rubrum
-      </xs:documentation>
-            <xs:documentation xml:lang="eng">contains the extra
-        sigillum notes on the document.
+            <xs:documentation xml:lang="deu"> Enthält Vermerke der ausstellenden Kanzlei auf der
+                Urkunde. Für Archivvermerke beim Empfänger vgl. rubrum </xs:documentation>
+            <xs:documentation xml:lang="eng">contains the extra sigillum notes on the document.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -2002,10 +2007,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:content-control>annotation</xrxe:content-control>
                 <xrxe:rows>2</xrxe:rows>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        beschreibt die institutionelle Referenz auf eine Archivale (mit Lagerort,
-        Signatur etc.)
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> beschreibt die institutionelle Referenz auf eine
+                Archivale (mit Lagerort, Signatur etc.) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2038,8 +2041,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Eine Angabe zu nicht mehr gültigen Fundort im Archiv
+            <xs:documentation xml:lang="deu"> Eine Angabe zu nicht mehr gültigen Fundort im Archiv
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -2079,9 +2081,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:menu-item>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Das Archiv als im Moment der Textentstehung existierende Institution,
-        die Schriftgut aus der Vergangenheit verwahrt.
+            <xs:documentation xml:lang="deu"> Das Archiv als im Moment der Textentstehung
+                existierende Institution, die Schriftgut aus der Vergangenheit verwahrt.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -2112,10 +2113,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:menu-item>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Ein Bestand in einem Archiv, d.h. gewöhnlich eine Gruppe von Archivgut,
-        das in einem Provenienzzusammenhang steht.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Ein Bestand in einem Archiv, d.h. gewöhnlich eine
+                Gruppe von Archivgut, das in einem Provenienzzusammenhang steht. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:simpleContent>
@@ -2138,10 +2137,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Die archivische Provenienz, d.h. die Registratur oder das erste Archiv,
-        das die Urkunde nach ihrem aktiven Gebrauch verwahrt hat.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Die archivische Provenienz, d.h. die Registratur oder
+                das erste Archiv, das die Urkunde nach ihrem aktiven Gebrauch verwahrt hat.
+            </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:group ref="biblArch"/>
@@ -2167,10 +2165,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:menu-item>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Die Bezeichnung einer Handschrift mit Lagerort und Signatur/Bezeichnung
-        innerhalb der lagernden Institution.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Die Bezeichnung einer Handschrift mit Lagerort und
+                Signatur/Bezeichnung innerhalb der lagernden Institution. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2203,7 +2199,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:menu-item>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Die Einrichtung, deren teil ein Archiv ist.</xs:documentation>
+            <xs:documentation xml:lang="deu">Die Einrichtung, deren teil ein Archiv
+                ist.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:simpleContent>
@@ -2230,8 +2227,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:menu-item>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Die Einrichtung, in der
-                ein Objekt gelagert ist.</xs:documentation>
+            <xs:documentation xml:lang="deu">Die Einrichtung, in der ein Objekt gelagert
+                ist.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:simpleContent>
@@ -2255,9 +2252,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:type-type>simpleType</xrxe:type-type>
                 <xrxe:mixed>false</xrxe:mixed>
             </xs:appinfo>
-            <xs:documentation>
-        Orginaldatierung in cei_MOM, eigentlich als quote type="Originaldatierung"
-      </xs:documentation>
+            <xs:documentation> Orginaldatierung in cei_MOM, eigentlich als quote
+                type="Originaldatierung" </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2283,8 +2279,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:rows>20</xrxe:rows>
                 <xrxe:content-control>annotation</xrxe:content-control>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Der eigentliche Urkundentext. Transkriptionselemente</xs:documentation>
+            <xs:documentation xml:lang="deu"> Der eigentliche Urkundentext.
+                Transkriptionselemente</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2315,8 +2311,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:menu-item>
                 <xrxe:content-control>annotation</xrxe:content-control>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Ein Absatz mit Fließtext
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">Ein Absatz mit Fließtext </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2330,11 +2325,17 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:element ref="hi"/>
                     <xs:element ref="c"/>
                     <xs:element ref="sup"/>
+                    <xs:element ref="scope"/>
+                    <!--Erweiterung-->
                 </xs:choice>
             </xs:sequence>
             <xs:attributeGroup ref="resp"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
+            <xs:attribute name="type"/>
+            <!--Erweiterung-->
+            <xs:attribute name="witness"/>
+            <!--Erweiterung-->
         </xs:complexType>
     </xs:element>
     <xs:element name="pTenor">
@@ -2355,8 +2356,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Ein Absatz
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">Ein Absatz </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2411,7 +2411,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Eine (meist einleitende) Anrufung Gottes</xs:documentation>
+            <xs:documentation xml:lang="deu">Eine (meist einleitende) Anrufung
+                Gottes</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2444,7 +2445,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Die Nennung des Ausstellers mit seinen Titeln</xs:documentation>
+            <xs:documentation xml:lang="deu">Die Nennung des Ausstellers mit seinen
+                Titeln</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2477,8 +2479,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Eine Adresse im
-        Urkundentext</xs:documentation>
+            <xs:documentation xml:lang="deu">Eine Adresse im Urkundentext</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2511,8 +2512,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Die
-        Veröffentlichungsformel</xs:documentation>
+            <xs:documentation xml:lang="deu">Die Veröffentlichungsformel</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2545,9 +2545,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Eine allgemeine Einleitung, die die Ausstellung der Urkunde begründet
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Eine allgemeine Einleitung, die die Ausstellung der
+                Urkunde begründet </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2580,10 +2579,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        erzählt die Ereignisse und Handlungen, die der Ausstellung der Urkunde
-        vorangegangen sind
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> erzählt die Ereignisse und Handlungen, die der
+                Ausstellung der Urkunde vorangegangen sind </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2618,7 +2615,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="en">clause expressing the request for formal documentation (cf. VID n. 326 http://www.cei.lmu.de/VID/VID.php?326)</xs:documentation>
+            <xs:documentation xml:lang="en">clause expressing the request for formal documentation
+                (cf. VID n. 326 http://www.cei.lmu.de/VID/VID.php?326)</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2635,7 +2633,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
     </xs:element>
     <xs:element name="intercessio">
         <xs:annotation>
-            <xs:documentation xml:lang="en">part of the text describing the intervention of a third to support a petition (cf. VID n. 328)</xs:documentation>
+            <xs:documentation xml:lang="en">part of the text describing the intervention of a third
+                to support a petition (cf. VID n. 328)</xs:documentation>
             <xs:appinfo source="EditVDU">
                 <xrxe:label>
                     <xrx:i18n>
@@ -2685,7 +2684,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
             <xs:documentation xml:lang="deu">enthält die eigentlichen
-        Rechtsverfügungen</xs:documentation>
+                Rechtsverfügungen</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2718,8 +2717,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">kündigt die
-        Beglaubigungsmittel an</xs:documentation>
+            <xs:documentation xml:lang="deu">kündigt die Beglaubigungsmittel an</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2736,10 +2734,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
     </xs:element>
     <xs:element name="sanctio">
         <xs:annotation>
-            <xs:documentation xml:lang="deu">
-        Die Textpassage, in der eine Strafe bei Brechen des Urkundeninhalts
-        angedroht wird.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Die Textpassage, in der eine Strafe bei Brechen des
+                Urkundeninhalts angedroht wird. </xs:documentation>
             <xs:appinfo source="EditVDU">
                 <xrxe:label>
                     <xrx:i18n>
@@ -2771,10 +2767,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
     </xs:element>
     <xs:element name="subscriptio">
         <xs:annotation>
-            <xs:documentation xml:lang="deu">
-        Unterschriftsbestandteile, wie echte Unterschriftszeilen,
-        Signumzeilen, Gegenzeichnungen durch Kanzleimitarbeiter usw.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Unterschriftsbestandteile, wie echte
+                Unterschriftszeilen, Signumzeilen, Gegenzeichnungen durch Kanzleimitarbeiter usw. </xs:documentation>
             <xs:appinfo source="EditVDU">
                 <xrxe:label>
                     <xrx:i18n>
@@ -2803,12 +2797,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
             </xs:sequence>
             <xs:attributeGroup ref="type">
                 <xs:annotation>
-                    <xs:documentation xml:lang="deu">
-            Die Unterscheidung in "Signumzeile", "Rekognitionszeile",
-            "Notarsunterschrift" (vgl. notariusSub: [strict!]) etc. Der
-            verwendete Sprachgebrauch sollte sich an das VID anlehnen oder in
-            der encodingDesc beschrieben werden.
-          </xs:documentation>
+                    <xs:documentation xml:lang="deu"> Die Unterscheidung in "Signumzeile",
+                        "Rekognitionszeile", "Notarsunterschrift" (vgl. notariusSub: [strict!]) etc.
+                        Der verwendete Sprachgebrauch sollte sich an das VID anlehnen oder in der
+                        encodingDesc beschrieben werden. </xs:documentation>
                 </xs:annotation>
             </xs:attributeGroup>
             <xs:attributeGroup ref="lang"/>
@@ -2833,8 +2825,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Datierung der Urkunde
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">Datierung der Urkunde </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2859,8 +2850,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">eine gebetsartige
-        abschließende Floskel</xs:documentation>
+            <xs:documentation xml:lang="deu">eine gebetsartige abschließende
+                Floskel</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2893,14 +2884,11 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        eine stark festgelegte Textpassage, die sich nur durch die individuellen
-        Bedingungen (Zeit, Ort, Person, syntaktische Einbindung) verändert,
-        die aber keine strukturierende Funktion im Sinne des
-        Urkundenformulars hat. Soweit möglich sollte sich der Inhalt des
-        Attributs "type" an der Terminologie des "Vocabulaire Internationale
-        de Diplomatique" orientieren.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> eine stark festgelegte Textpassage, die sich nur durch
+                die individuellen Bedingungen (Zeit, Ort, Person, syntaktische Einbindung)
+                verändert, die aber keine strukturierende Funktion im Sinne des Urkundenformulars
+                hat. Soweit möglich sollte sich der Inhalt des Attributs "type" an der Terminologie
+                des "Vocabulaire Internationale de Diplomatique" orientieren. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2934,8 +2922,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:content-control>annotation</xrxe:content-control>
                 <xrxe:rows>5</xrxe:rows>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Die Notarsunterschrift
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">Die Notarsunterschrift </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2958,8 +2945,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Das Notarszeichen
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">Das Notarszeichen </xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:simpleContent>
@@ -2997,6 +2983,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xs:element ref="sic"/>
                 <xs:element ref="handShift"/>
                 <xs:element ref="unclear"/>
+                <xs:element ref="w"/>
+                <!--Erweiterung-->
+                <xs:element ref="pc"/>
+                <!--Erweiterung-->
             </xs:choice>
         </xs:sequence>
     </xs:group>
@@ -3018,13 +3008,11 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Ein signifikant großer unbeschriebener Raum in der
-        Transkriptionsvorlage. Der Leerraum wird mit den Attributen "dim"
-        (horizontal/vertical) und "extent" (Größe) beschrieben: Z.B.
-        dim="vertical" extent="4 Zeilen". Ist die Lücke durch eine Rasur
-        entstanden, ist ein leeres Element "del" vorzuziehen.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Ein signifikant großer unbeschriebener Raum in der
+                Transkriptionsvorlage. Der Leerraum wird mit den Attributen "dim"
+                (horizontal/vertical) und "extent" (Größe) beschrieben: Z.B. dim="vertical"
+                extent="4 Zeilen". Ist die Lücke durch eine Rasur entstanden, ist ein leeres Element
+                "del" vorzuziehen. </xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:attribute name="dim">
@@ -3063,11 +3051,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        enthält beschädigte Passagen, d.h. Stellen, in denen die physischen
-        Eigenschaften des Textes ihn nur schwer oder gar nicht entzifferbar
-        machen.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> enthält beschädigte Passagen, d.h. Stellen, in denen
+                die physischen Eigenschaften des Textes ihn nur schwer oder gar nicht entzifferbar
+                machen. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3079,6 +3065,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:element ref="hi"/>
                     <xs:element ref="handShift"/>
                     <xs:element ref="pict"/>
+                    <xs:element ref="pc"/>
+                    <!--Erweiterung-->
+                    <xs:element ref="w"/>
+                    <!--Erweiterung-->
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
             </xs:sequence>
@@ -3131,7 +3121,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu"> enthält Text, der nicht eindeutig lesbar sind. </xs:documentation>
+            <xs:documentation xml:lang="deu"> enthält Text, der nicht eindeutig lesbar sind.
+            </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3216,11 +3207,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        ein Handwechsel im Dokument. Das Attribut "hand" benennt die Hand des
-        folgenden Textes, falls z.B. über eine Referenz auf eine Liste der
-        Schreiber (Element handList) möglich.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> ein Handwechsel im Dokument. Das Attribut "hand"
+                benennt die Hand des folgenden Textes, falls z.B. über eine Referenz auf eine Liste
+                der Schreiber (Element handList) möglich. </xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:attributeGroup ref="hand"/>
@@ -3238,13 +3227,11 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Varianten anderer kopialer Überlieferungen werden über das Referenzwort als
-        Element "lem" und die Varianten als Elemente "rdg" mit dem Attribut
-        "sigil" für die Sigle.
-            </xs:documentation>
-            <xs:documentation xml:lang="eng">note in a critical
-        apparatus listing variants</xs:documentation>
+            <xs:documentation xml:lang="deu"> Varianten anderer kopialer Überlieferungen werden über
+                das Referenzwort als Element "lem" und die Varianten als Elemente "rdg" mit dem
+                Attribut "sigil" für die Sigle. </xs:documentation>
+            <xs:documentation xml:lang="eng">note in a critical apparatus listing
+                variants</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="false">
             <xs:sequence>
@@ -3258,8 +3245,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                 </xrx:i18n>
                             </xrxe:label>
                         </xs:appinfo>
-                        <xs:documentation xml:lang="deu">Die im Haupttext
-              erscheinende Version.</xs:documentation>
+                        <xs:documentation xml:lang="deu">Die im Haupttext erscheinende
+                            Version.</xs:documentation>
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:sequence>
@@ -3269,6 +3256,16 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                 <xs:group ref="layout"/>
                                 <xs:group ref="reference"/>
                                 <xs:group ref="textualElements"/>
+                                <xs:element ref="w"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="pc"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="space"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="damage"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="supplied"/>
+                                <!--Erweiterung-->
                             </xs:choice>
                         </xs:sequence>
                         <xs:attributeGroup ref="wit"/>
@@ -3285,17 +3282,26 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                 </xrx:i18n>
                             </xrxe:label>
                         </xs:appinfo>
-                        <xs:documentation xml:lang="eng">reading
-            </xs:documentation>
+                        <xs:documentation xml:lang="eng">reading </xs:documentation>
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:sequence>
                             <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                <xs:element ref="w"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="add"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="app"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="foreign"/>
+                                <!--Erweiterung-->
                                 <xs:group ref="biblArch"/>
                                 <xs:group ref="layout"/>
                                 <xs:group ref="reference"/>
                             </xs:choice>
                         </xs:sequence>
+                        <xs:attribute name="type"/>
+                        <!--Erweiterung-->
                         <xs:attributeGroup ref="wit"/>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
@@ -3322,7 +3328,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Der ausgeschriebene Text einer Abkürzung.</xs:documentation>
+            <xs:documentation xml:lang="deu">Der ausgeschriebene Text einer
+                Abkürzung.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3339,8 +3346,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="abbr">
                 <xs:annotation>
-                    <xs:documentation xml:lang="deu">Die Buchstaben der
-            Abkürzung</xs:documentation>
+                    <xs:documentation xml:lang="deu">Die Buchstaben der Abkürzung</xs:documentation>
                 </xs:annotation>
             </xs:attributeGroup>
             <xs:attributeGroup ref="certainty"/>
@@ -3365,10 +3371,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Ein Text, der augenfällige Fehler aufweist, aber in der Vorlage so
-        steht. Aber auch für den Text, der vor einer Korrektur stand.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Ein Text, der augenfällige Fehler aufweist, aber in
+                der Vorlage so steht. Aber auch für den Text, der vor einer Korrektur stand.
+            </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3410,10 +3415,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:menu-item>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Eine Textpassage, die im Text zunächst anders lautete und dann mit dem
-        Inhalt des Elements korrigiert worden ist.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Eine Textpassage, die im Text zunächst anders lautete
+                und dann mit dem Inhalt des Elements korrigiert worden ist. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3453,10 +3456,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Ein noch lesbarer Text der im Original getilgt worden ist (z.B. durch
-        Durchstreichen, Unterpunkten, Rasur).
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Ein noch lesbarer Text der im Original getilgt worden
+                ist (z.B. durch Durchstreichen, Unterpunkten, Rasur). </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3494,9 +3495,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Nachträgliche Hinzufügungen im Text, die nicht anderen Text ersetzen.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Nachträgliche Hinzufügungen im Text, die nicht anderen
+                Text ersetzen. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3510,10 +3510,14 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:element ref="del"/>
                     <xs:element ref="damage"/>
                     <xs:element ref="handShift"/>
+                    <xs:element ref="w"/>
+                    <!--Erweiterung-->
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
             </xs:sequence>
+            <xs:attribute name="status"/>
+            <!--Erweiterung-->
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -3537,9 +3541,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-                Hinzufügungen von Text, der in der Vorlage nicht dokumentiert ist, durch den Editor.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Hinzufügungen von Text, der in der Vorlage nicht
+                dokumentiert ist, durch den Editor. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3549,6 +3552,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:element ref="pb"/>
                     <xs:element ref="damage"/>
                     <xs:element ref="expan"/>
+                    <xs:element ref="w"/>
+                    <!--Erweiterung-->
+                    <xs:element ref="pc"/>
+                    <!--Erweiterung-->
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
@@ -3556,6 +3563,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
+            <xs:attribute name="source"/>
+            <!--Erweiterung-->
+            <xs:attribute name="reason"/>
+            <!--Erweiterung-->
         </xs:complexType>
     </xs:element>
     <xs:element name="pict">
@@ -3575,11 +3586,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:menu-item>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        graphische, zeichenartige Elemente im Text. Mit Hilfe des type-Attribut genauer
-        zu bestimmen, mit entity oder URL auf eine externe Art der
-        Darstellung zu verweisen.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> graphische, zeichenartige Elemente im Text. Mit Hilfe
+                des type-Attribut genauer zu bestimmen, mit entity oder URL auf eine externe Art der
+                Darstellung zu verweisen. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:group ref="transcription"/>
@@ -3598,11 +3607,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Diese ganze Gruppe ist auf ihre Relevanz hin zu überprüfen, da sie
-        graphische nicht semantische Informationen auszuzeichnen scheint.
-        [strict!]
-             </xs:documentation>
+            <xs:documentation xml:lang="deu"> Diese ganze Gruppe ist auf ihre Relevanz hin zu
+                überprüfen, da sie graphische nicht semantische Informationen auszuzeichnen scheint.
+                [strict!] </xs:documentation>
         </xs:annotation>
         <xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
@@ -3662,18 +3669,14 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Ein hochgestelltes Zeichen, dessen logische Funktion "hochgestellt"
-        ist, macht das Sinn? Evtl. nur cei_MOM spezifisch! [strict!] Der in
-        Urkunden relevante Fall sind die Ordinalzahlen, in denen das
-        hochgestellte Zeichen nämlich nicht für eine Abkürzung steht,
-        sondern den Bezug einer Zahlenangabe über die Endung markiert. Die
-        TEI sähe für Ordinalzahlen das Element "num", das mit den Attributen
-        type und value die Funktion als Ordinalzahl und den eigentlichen
-        Wert notiert. Es bleibt dabei jedoch unklar, wie zwischen dem
-        Zahlzeichen und seiner Markierung als Ordinalzahl unterschieden
-        werden kann.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Ein hochgestelltes Zeichen, dessen logische Funktion
+                "hochgestellt" ist, macht das Sinn? Evtl. nur cei_MOM spezifisch! [strict!] Der in
+                Urkunden relevante Fall sind die Ordinalzahlen, in denen das hochgestellte Zeichen
+                nämlich nicht für eine Abkürzung steht, sondern den Bezug einer Zahlenangabe über
+                die Endung markiert. Die TEI sähe für Ordinalzahlen das Element "num", das mit den
+                Attributen type und value die Funktion als Ordinalzahl und den eigentlichen Wert
+                notiert. Es bleibt dabei jedoch unklar, wie zwischen dem Zahlzeichen und seiner
+                Markierung als Ordinalzahl unterschieden werden kann. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:attributeGroup ref="type"/>
@@ -3699,12 +3702,12 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
                 <xrxe:empty/>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Zeilenwechsel in der
-        Vorlage.</xs:documentation>
-            <xs:documentation xml:lang="eng">Line break in the source.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">Zeilenwechsel in der Vorlage.</xs:documentation>
+            <xs:documentation xml:lang="eng">Line break in the source. </xs:documentation>
         </xs:annotation>
         <xs:complexType>
+            <xs:attribute name="break"/>
+            <!--Erweiterung-->
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -3725,10 +3728,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:menu-item>
                 <xrxe:empty/>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Seitenwechsel in der
-        Vorlage.</xs:documentation>
-            <xs:documentation xml:lang="eng">Page break in the source.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">Seitenwechsel in der Vorlage.</xs:documentation>
+            <xs:documentation xml:lang="eng">Page break in the source. </xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:attributeGroup ref="standard"/>
@@ -3752,19 +3753,16 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Ein einzelnes Zeichen in der Vorlage, das nicht mit dem gewählten
-        Zeichensatz dargestellt werden kann. Die Art und Weise der
-        Darstellung und Verarbeitung ist in der encodingDesc zu beschreiben.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Ein einzelnes Zeichen in der Vorlage, das nicht mit
+                dem gewählten Zeichensatz dargestellt werden kann. Die Art und Weise der Darstellung
+                und Verarbeitung ist in der encodingDesc zu beschreiben. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:attributeGroup ref="type">
                 <xs:annotation>
-                    <xs:documentation xml:lang="deu">
-            Der Name des Zeichens, wie er in der encodingDesc/profileDesc
-            auftaucht und mit einer Darstellungsform versehen wird.
-          </xs:documentation>
+                    <xs:documentation xml:lang="deu"> Der Name des Zeichens, wie er in der
+                        encodingDesc/profileDesc auftaucht und mit einer Darstellungsform versehen
+                        wird. </xs:documentation>
                 </xs:annotation>
             </xs:attributeGroup>
             <xs:attributeGroup ref="standard"/>
@@ -3788,11 +3786,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        durch graphische Merkmale hervorgehobene Textpassagen, die keine rein
-        inhaltliche Funktion haben, z.B. vergrößerte Initialen, gesperrte
-        Texte, Texte zwischen Referenzpunkten, Elongata
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> durch graphische Merkmale hervorgehobene Textpassagen,
+                die keine rein inhaltliche Funktion haben, z.B. vergrößerte Initialen, gesperrte
+                Texte, Texte zwischen Referenzpunkten, Elongata </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3865,14 +3861,11 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Ein leeres Element, das auf ein anderes Element im Text verweist, das
-        ein id-Attribut besitzt. Die ID des Zieles wird im Attribut target
-        notiert. Verweise auf Elemente außerhalb des aktuellen Dokuments
-        sind mit dem Element xptr zu verwirklichen. Ist der Verweis als
-        Textpassage im aktuellen Element ausformuliert, ist das Element
-        "ref" zu verwenden.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Ein leeres Element, das auf ein anderes Element im
+                Text verweist, das ein id-Attribut besitzt. Die ID des Zieles wird im Attribut
+                target notiert. Verweise auf Elemente außerhalb des aktuellen Dokuments sind mit dem
+                Element xptr zu verwirklichen. Ist der Verweis als Textpassage im aktuellen Element
+                ausformuliert, ist das Element "ref" zu verwenden. </xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:simpleContent>
@@ -3901,14 +3894,12 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:menu-item>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Das Element enthält eine Textpassage, die auf eine anderes Element im
-        Text verweist, das ein id-Attribut besitzt. Die ID des Zieles wird
-        im Attribut "target" angegeben. Verweise auf Elemente außerhalb des
-        aktuellen Dokuments sind mit dem Element xref zu verwirklichen.
-        Ersetzt das Tag einen textlichen Verweis bzw. wird der Verweistext
-        automatisch erzeugt, ist das Element "ptr" zu verwenden.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Das Element enthält eine Textpassage, die auf eine
+                anderes Element im Text verweist, das ein id-Attribut besitzt. Die ID des Zieles
+                wird im Attribut "target" angegeben. Verweise auf Elemente außerhalb des aktuellen
+                Dokuments sind mit dem Element xref zu verwirklichen. Ersetzt das Tag einen
+                textlichen Verweis bzw. wird der Verweistext automatisch erzeugt, ist das Element
+                "ptr" zu verwenden. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:simpleContent>
@@ -3940,10 +3931,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:content-control>annotation</xrxe:content-control>
                 <xrxe:rows>3</xrxe:rows>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Ein ergänzender Text zu einer bestimmten Textstelle, der im Druck
-        gewöhnlich als Marginalie, Fuß- oder Endnote dargestellt wird.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Ein ergänzender Text zu einer bestimmten Textstelle,
+                der im Druck gewöhnlich als Marginalie, Fuß- oder Endnote dargestellt wird.
+            </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3991,8 +3981,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                         <xs:appinfo source="EditVDU">
                             <xrxe:relevant>false</xrxe:relevant>
                         </xs:appinfo>
-                        <xs:documentation xml:lang="deu">Eine Überschrift
-            </xs:documentation>
+                        <xs:documentation xml:lang="deu">Eine Überschrift </xs:documentation>
                     </xs:annotation>
                 </xs:element>
                 <xs:element ref="h1">
@@ -4064,12 +4053,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Jede beliebige Art von Textabschnitt, die einen inhaltlichen
-        Sinnabschnitt von mindestens einem Absatz umschließt und nicht durch
-        speziellere Elemente (z.B. Formularteile, abstract) beschrieben
-        werden kann.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Jede beliebige Art von Textabschnitt, die einen
+                inhaltlichen Sinnabschnitt von mindestens einem Absatz umschließt und nicht durch
+                speziellere Elemente (z.B. Formularteile, abstract) beschrieben werden kann.
+            </xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
@@ -4092,8 +4079,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:label>
                 <xrxe:min-occur>0</xrxe:min-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Enthält die Fußnoten zur
-        Urkunde.</xs:documentation>
+            <xs:documentation xml:lang="deu">Enthält die Fußnoten zur Urkunde.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
@@ -4122,12 +4108,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Eine Textpassage, die nicht in der in der übergeordnet definierten
-        Sprache formuliert ist (z.B. deutsche Namen in lateinischen
-        Urkunden, eingeflochtene lateinische Textpassagen im deutschen
-        Vorspann etc.)
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Eine Textpassage, die nicht in der in der übergeordnet
+                definierten Sprache formuliert ist (z.B. deutsche Namen in lateinischen Urkunden,
+                eingeflochtene lateinische Textpassagen im deutschen Vorspann etc.)
+            </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4158,12 +4142,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Ein wörtliches Zitat gemeinsam mit der Herkunftsangabe. Die Quelle
-        dabei nicht auf explizit bibliographische Angaben beschränkt,
-        sondern kann auch kanonische Referenzen (wie z.B. Bibelzitate)
-        enthalten.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Ein wörtliches Zitat gemeinsam mit der
+                Herkunftsangabe. Die Quelle dabei nicht auf explizit bibliographische Angaben
+                beschränkt, sondern kann auch kanonische Referenzen (wie z.B. Bibelzitate)
+                enthalten. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="false">
             <xs:sequence>
@@ -4192,17 +4174,14 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        enthält ein wörtliches Zitat. Die TEI sieht das Element für intertextuelle
-        Zitate vor. Alternativ und lauf Guidelines der TEI im Zweifelsfall
-        vorzuziehen ist das Element "q" vor, das für intratextuelle Zitate
-        zu verwenden ist. Da in Urkunden jedoch Zitate gewöhnlich aus einer
-        externen Textquelle schöpfen und nicht einem anderen Sprecher im
-        Text zugeordnet sind, ist in diesem Kontext das Element "quote" im
-        Zweifelsfall vorzuziehen. [strict!] Zu diskutieren ist nur der Fall
-        eines angekündigten wörtlichen Zitats, z.B: wir bestätigen die
-        Urkunde unseres Vaters die folgenden Wortlaut hat: ....
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> enthält ein wörtliches Zitat. Die TEI sieht das
+                Element für intertextuelle Zitate vor. Alternativ und lauf Guidelines der TEI im
+                Zweifelsfall vorzuziehen ist das Element "q" vor, das für intratextuelle Zitate zu
+                verwenden ist. Da in Urkunden jedoch Zitate gewöhnlich aus einer externen Textquelle
+                schöpfen und nicht einem anderen Sprecher im Text zugeordnet sind, ist in diesem
+                Kontext das Element "quote" im Zweifelsfall vorzuziehen. [strict!] Zu diskutieren
+                ist nur der Fall eines angekündigten wörtlichen Zitats, z.B: wir bestätigen die
+                Urkunde unseres Vaters die folgenden Wortlaut hat: .... </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4266,8 +4245,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Eine Liste
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">Eine Liste </xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:sequence maxOccurs="unbounded">
@@ -4287,8 +4265,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Ein Listenpunkt
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">Ein Listenpunkt </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4330,11 +4307,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Ein Maßangabe inkl. Maßeinheit. Das Attribut "value" enthält eine
-        vereinheitliche Form der Angabe die aus einem numerischen Wert und
-        einer Maßangabe besteht.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Ein Maßangabe inkl. Maßeinheit. Das Attribut "value"
+                enthält eine vereinheitliche Form der Angabe die aus einem numerischen Wert und
+                einer Maßangabe besteht. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4367,10 +4342,17 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Eine Zahlenangabe
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">Eine Zahlenangabe </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
+            <xs:sequence>
+                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element ref="w"/>
+                    <!--Erweiterung-->
+                    <xs:element ref="pc"/>
+                    <!--Erweiterung-->
+                </xs:choice>
+            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attribute name="value" type="xs:double"/>
             <xs:attributeGroup ref="lang"/>
@@ -4395,8 +4377,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xs:element ref="testis"/>
                 <xs:choice>
                     <xs:annotation>
-                        <xs:documentation xml:lang="deu">Datumsangaben
-            </xs:documentation>
+                        <xs:documentation xml:lang="deu">Datumsangaben </xs:documentation>
                     </xs:annotation>
                     <xs:element ref="date"/>
                     <xs:element ref="dateRange"/>
@@ -4410,6 +4391,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
         <xs:choice>
             <xs:element ref="date"/>
             <xs:element ref="dateRange"/>
+            <xs:element ref="w"/>
+            <!--Erweiterung-->
         </xs:choice>
     </xs:group>
     <xs:element name="index">
@@ -4431,10 +4414,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
                 <xrxe:content-control>annotation</xrxe:content-control>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        ein Eintrag für eine erschließende Liste von Stichwörtern (Register,
-        Index)
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> ein Eintrag für eine erschließende Liste von
+                Stichwörtern (Register, Index) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4507,9 +4488,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Die Angabe eines spezifischen Tages in einem Kalender (=Datumsangabe).
-      </xs:documentation>
+            <xs:documentation xml:lang="deu"> Die Angabe eines spezifischen Tages in einem Kalender
+                (=Datumsangabe). </xs:documentation>
         </xs:annotation>
         <xs:alternative test="ancestor::issued" type="dateNormalized"
             xpathDefaultNamespace="##targetNamespace"/>
@@ -4522,6 +4502,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xs:element ref="num"/>
                 <xs:group ref="Originalbefund"/>
                 <xs:element ref="ref"/>
+                <xs:element ref="figure"/>
+                <!--Erweiterung-->
             </xs:choice>
         </xs:sequence>
         <xs:attributeGroup ref="lang"/>
@@ -4559,10 +4541,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Ein Zeitraum, die Werte des kleinsten und des größten zutreffenden
-        Datums in den Attributen "from" und "to"
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Ein Zeitraum, die Werte des kleinsten und des größten
+                zutreffenden Datums in den Attributen "from" und "to" </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4692,8 +4672,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:menu-item>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">ein Personenname
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">ein Personenname </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4701,7 +4680,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:choice>
                         <xs:annotation>
                             <xs:documentation xml:lang="deu">Geographische Angaben
-              </xs:documentation>
+                            </xs:documentation>
                         </xs:annotation>
                         <xs:element ref="persName"/>
                         <xs:element ref="orgName"/>
@@ -4771,7 +4750,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:menu-item>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">ein Familienname oder anderer Beiname, der zur Unterscheidung einer Person z.B. durch Gruppenzuordnung dient.</xs:documentation>
+            <xs:documentation xml:lang="deu">ein Familienname oder anderer Beiname, der zur
+                Unterscheidung einer Person z.B. durch Gruppenzuordnung dient.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4787,6 +4767,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xs:choice>
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
+                    <xs:element ref="orgName"/>
+                    <!--Erweiterung-->
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
             </xs:sequence>
@@ -4812,7 +4794,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 </xrxe:menu-item>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">ein Rollennamen, z.B. Adelstitel, Anrede, Epitheton ...</xs:documentation>
+            <xs:documentation xml:lang="deu">ein Rollennamen, z.B. Adelstitel, Anrede, Epitheton
+                ...</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4820,6 +4803,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
+                    <xs:group ref="Sachauszeichnung"/>
+                    <!--Erweiterung-->
                 </xs:choice>
             </xs:sequence>
             <xs:attributeGroup ref="lang"/>
@@ -4845,12 +4830,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Der Name der Person, die die Urkunde erhält (als Adressat oder als
-        Begünstigter)
-            </xs:documentation>
-            <xs:documentation xml:lang="eng">
-        The name of the person who is receives the document.
+            <xs:documentation xml:lang="deu"> Der Name der Person, die die Urkunde erhält (als
+                Adressat oder als Begünstigter) </xs:documentation>
+            <xs:documentation xml:lang="eng"> The name of the person who is receives the document.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -4862,7 +4844,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:choice>
                         <xs:annotation>
                             <xs:documentation xml:lang="deu">Geographische Angaben
-              </xs:documentation>
+                            </xs:documentation>
                         </xs:annotation>
                         <xs:element ref="placeName"/>
                         <xs:element ref="geogName"/>
@@ -4892,11 +4874,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Der Aussteller der
-        Urkunde.</xs:documentation>
-            <xs:documentation xml:lang="eng">
-        marks a person the CID describes as follows: L'auteur d'un acte écrit est
-        la personne au nom de qui cet acte est intitulé.
+            <xs:documentation xml:lang="deu">Der Aussteller der Urkunde.</xs:documentation>
+            <xs:documentation xml:lang="eng"> marks a person the CID describes as follows: L'auteur
+                d'un acte écrit est la personne au nom de qui cet acte est intitulé.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -4907,7 +4887,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:choice>
                         <xs:annotation>
                             <xs:documentation xml:lang="deu">Geographische Angaben
-              </xs:documentation>
+                            </xs:documentation>
                         </xs:annotation>
                         <xs:element ref="placeName"/>
                         <xs:element ref="geogName"/>
@@ -4939,8 +4919,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Ein einzelner Zeuge.
-      </xs:documentation>
+            <xs:documentation xml:lang="deu">Ein einzelner Zeuge. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4950,7 +4929,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:choice>
                         <xs:annotation>
                             <xs:documentation xml:lang="deu">Geographische Angaben
-              </xs:documentation>
+                            </xs:documentation>
                         </xs:annotation>
                         <xs:element ref="placeName"/>
                         <xs:element ref="geogName"/>
@@ -4991,8 +4970,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation>der Name einer Region, eines Bundeslandes u.ä.
-      </xs:documentation>
+            <xs:documentation>der Name einer Region, eines Bundeslandes u.ä. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:attributeGroup ref="type"/>
@@ -5011,10 +4989,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation>
-        der Name eines völkerrechtlich selbständigen Staates (z.B. Deutschland,
-        Ungarn ...)
-            </xs:documentation>
+            <xs:documentation> der Name eines völkerrechtlich selbständigen Staates (z.B.
+                Deutschland, Ungarn ...) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:attributeGroup ref="type"/>
@@ -5025,8 +5001,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
     </xs:element>
     <xs:element name="settlement">
         <xs:annotation>
-            <xs:documentation>der Name einer Siedlung (Dorf, Stadt ...)
-      </xs:documentation>
+            <xs:documentation>der Name einer Siedlung (Dorf, Stadt ...) </xs:documentation>
             <xs:appinfo source="EditVDU">
                 <xrxe:label>
                     <xrx:i18n>
@@ -5067,11 +5042,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
                 <xrxe:content-control>annotation</xrxe:content-control>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Enthält geographische Angaben, die sich auf menschliche Siedlung oder
-        politische Einheiten beziehen, d.h. Orte, Hofnamen, Klöster, Burgen,
-        Bundesländer, Herrschaften, Staaten etc.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Enthält geographische Angaben, die sich auf
+                menschliche Siedlung oder politische Einheiten beziehen, d.h. Orte, Hofnamen,
+                Klöster, Burgen, Bundesländer, Herrschaften, Staaten etc. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -5079,6 +5052,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:element ref="index"/>
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
+                    <xs:element ref="placeName"/>
+                    <!--Erweiterung-->
+                    <xs:element ref="persName"/>
+                    <!--Erweiterung-->
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
             </xs:sequence>
@@ -5107,9 +5084,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Enhält naturräumliche geographische Angaben wie Bergnamen, Flußnamen,
-        Landstriche, die keine politische Einheit bilden.
+            <xs:documentation xml:lang="deu"> Enhält naturräumliche geographische Angaben wie
+                Bergnamen, Flußnamen, Landstriche, die keine politische Einheit bilden.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -5139,10 +5115,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                                 </xrx:i18n>
                             </xrxe:label>
                         </xs:appinfo>
-                        <xs:documentation xml:lang="deu">
-              Der Autor eines Textes. Insbesondere im Rahmen einer
-              bibliographischen Angabe gebraucht.
-                        </xs:documentation>
+                        <xs:documentation xml:lang="deu"> Der Autor eines Textes. Insbesondere im
+                            Rahmen einer bibliographischen Angabe gebraucht. </xs:documentation>
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:sequence>
@@ -5260,13 +5234,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
                 <xrxe:content-control>input</xrxe:content-control>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Bibliographische Angaben. Es ist zu diskutieren, ob das Element auch für kanonische
-        Angaben (wie z.B. Bibelzitate) verwendet werden kann, oder ob dafür
-        ein eigenes Element notwendig ist. [strict!]
-            </xs:documentation>
-            <xs:documentation xml:lang="eng">Bibliographic
-        informations</xs:documentation>
+            <xs:documentation xml:lang="deu"> Bibliographische Angaben. Es ist zu diskutieren, ob
+                das Element auch für kanonische Angaben (wie z.B. Bibelzitate) verwendet werden
+                kann, oder ob dafür ein eigenes Element notwendig ist. [strict!] </xs:documentation>
+            <xs:documentation xml:lang="eng">Bibliographic informations</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -5278,6 +5249,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     <xs:group ref="BibliographicInformation"/>
                 </xs:choice>
             </xs:sequence>
+            <xs:attribute name="status"/>
+            <!--Erweiterung-->
+            <xs:attribute name="type"/>
+            <!--Erweiterung-->
             <xs:attributeGroup ref="key"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -5318,11 +5293,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:menu-item>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Umfang einer bibliographischen Angabe, insbesondere in einem
-        übergeordneten bibliographsichen Zusammenhang. Z.B. die Seitenzahlen
-        eines Aufsatzes in einem Sammelband, die Fundstelle einer Urkunde in
-        einem Kopialbuch.
+            <xs:documentation xml:lang="deu"> Umfang einer bibliographischen Angabe, insbesondere in
+                einem übergeordneten bibliographsichen Zusammenhang. Z.B. die Seitenzahlen eines
+                Aufsatzes in einem Sammelband, die Fundstelle einer Urkunde in einem Kopialbuch.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
@@ -5352,9 +5325,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-        Leeres Element, das als Zielpunkt einer Referenz dient.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Leeres Element, das als Zielpunkt einer Referenz
+                dient. </xs:documentation>
         </xs:annotation>
         <xs:complexType>
             <xs:simpleContent>
@@ -5374,10 +5346,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation>
-        CEI_MOM: Nur für vorläufigen Gebrauch um Konversionen aus HTML zu
-        erleichtern!!!! [strict!]
-            </xs:documentation>
+            <xs:documentation> CEI_MOM: Nur für vorläufigen Gebrauch um Konversionen aus HTML zu
+                erleichtern!!!! [strict!] </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:simpleContent>
@@ -5424,14 +5394,14 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                             <xrx:default>certainty</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"
+                    />
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">
-          Für Genauigkeitsangaben z.B. bei Datierungen, werden mit
-          Schlüsselwörtern (zu benennen in der encodingDesc) oder kurzen
-          Beschreibungen charakterisiert werden. auch für
-          Fälschungsmarkierungen? [strict!]
-             </xs:documentation>
+                <xs:documentation xml:lang="deu"> Für Genauigkeitsangaben z.B. bei Datierungen,
+                    werden mit Schlüsselwörtern (zu benennen in der encodingDesc) oder kurzen
+                    Beschreibungen charakterisiert werden. auch für Fälschungsmarkierungen?
+                    [strict!] </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5462,7 +5432,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                             <xrx:default>reg</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"
+                    />
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
@@ -5478,8 +5450,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">Der verantwortliche Bearbeiter für die
-                    Kodierung, den Inhalt der Kodierung oder die vergebenen Attribute.</xs:documentation>
+                <xs:documentation xml:lang="deu">Der verantwortliche Bearbeiter für die Kodierung,
+                    den Inhalt der Kodierung oder die vergebenen Attribute.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5493,7 +5465,9 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                             <xrx:default>type</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"
+                    />
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
@@ -5578,10 +5552,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">
-          Funktion des Tags im besonderen Kontext: z.B. Datum als ... ist so
-          eigentlich nicht richtig.
-             </xs:documentation>
+                <xs:documentation xml:lang="deu"> Funktion des Tags im besonderen Kontext: z.B.
+                    Datum als ... ist so eigentlich nicht richtig. </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5596,10 +5568,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">
-          Ein eindeutiger Bezeichner, der in einer externen Liste aufgelöst
-          werden kann.
-             </xs:documentation>
+                <xs:documentation xml:lang="deu"> Ein eindeutiger Bezeichner, der in einer externen
+                    Liste aufgelöst werden kann. </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5612,7 +5582,7 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
         <xs:attributeGroup ref="certainty"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="value">
-        <xs:attribute name="value" type="normalizedDateValue">
+        <xs:attribute name="value" type="normalizedDateValue" use="required">
             <xs:annotation>
                 <xs:appinfo source="EditVDU">
                     <xrxe:label>
@@ -5708,6 +5678,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
         <xs:attributeGroup ref="n"/>
         <xs:attributeGroup ref="facs"/>
         <xs:attributeGroup ref="resp"/>
+        <xs:attributeGroup ref="rend"/>
+        <!--Erweiterung-->
     </xs:attributeGroup>
     <xs:attributeGroup name="facs">
         <xs:attribute name="facs">
@@ -5736,10 +5708,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">
-          Eine im gesamten Dokument eindeutige ID, die mit einem Buchtstaben
-          beginnt.
-              </xs:documentation>
+                <xs:documentation xml:lang="deu"> Eine im gesamten Dokument eindeutige ID, die mit
+                    einem Buchstaben beginnt. </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5754,9 +5724,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">
-          Eine lokale Identifikation, wie z.B. die Fußnotennummer.
-        </xs:documentation>
+                <xs:documentation xml:lang="deu"> Eine lokale Identifikation, wie z.B. die
+                    Fußnotennummer. </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5772,10 +5741,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrxe:label>
                     <xrxe:relevant context="='quote' or $context='foreign' or $context='cit'"/>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">
-          Die Sprache des Elements und aller Unterelemente, solange nichts
-          anderes angegeben ist.
-             </xs:documentation>
+                <xs:documentation xml:lang="deu"> Die Sprache des Elements und aller Unterelemente,
+                    solange nichts anderes angegeben ist. </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5791,10 +5758,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                     </xrxe:label>
                     <xrxe:relevant context="='hi'"/>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">
-          Die Art der Darstellung des Elements, insbesondere Bezeichnung der
-          Schriftart bei Hervorhebungen.
-                </xs:documentation>
+                <xs:documentation xml:lang="deu"> Die Art der Darstellung des Elements, insbesondere
+                    Bezeichnung der Schriftart bei Hervorhebungen. </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5843,7 +5808,8 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="en">Reference to textual witness identified in charter description.</xs:documentation>
+                <xs:documentation xml:lang="en">Reference to textual witness identified in charter
+                    description.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5858,9 +5824,10 @@ fehlerhafte Rekursionen zu vermeiden (GV) 2006-03-19
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">Bezeichner der 
-                    Ressource (bevorzugt eine URI), auf der Inhalt eines Textes verweist.</xs:documentation>
-                <xs:documentation xml:lang="en">Reference to a resource (preferable URI) wich is referenced by the content of a text.</xs:documentation>
+                <xs:documentation xml:lang="deu">Bezeichner der Ressource (bevorzugt eine URI), auf
+                    der Inhalt eines Textes verweist.</xs:documentation>
+                <xs:documentation xml:lang="en">Reference to a resource (preferable URI) wich is
+                    referenced by the content of a text.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>

--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -1,8 +1,4 @@
-<xs:schema xmlns="http://www.monasterium.net/NS/cei" xmlns:xerces="http://xerces.apache.org"
-    xmlns:xrxe="http://www.monasterium.net/NS/xrxe" xmlns:xrx="http://www.monasterium.net/NS/xrx"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified"
-    elementFormDefault="qualified" targetNamespace="http://www.monasterium.net/NS/cei" id="cei"
-    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
+<?xml version="1.0" encoding="UTF-8"?><xs:schema xmlns="http://www.monasterium.net/NS/cei" xmlns:xerces="http://xerces.apache.org" xmlns:xrxe="http://www.monasterium.net/NS/xrxe" xmlns:xrx="http://www.monasterium.net/NS/xrx" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.monasterium.net/NS/cei" id="cei" vc:minVersion="1.1">
     <xs:element name="cei">
         <xs:annotation>
             <xs:documentation xml:lang="deu"> Wurzelelement für alle Dokumente, die den Regeln der
@@ -27,32 +23,32 @@
                 lang auf ausgewählte Elemente beschränkt (vgl. EditMOM), nota in
                 "diplomaticAnalysis" eingefügt. measure mit num/index und Originalbefund versehen.
                 GV 2006-08-09: seal, witness und alle Subelemente als globale Elemente definiert,
-                den neuen globalen Elementen &lt;menu> vergeben (GV) 2006-07-06: pict zu
+                den neuen globalen Elementen &lt;menu&gt; vergeben (GV) 2006-07-06: pict zu
                 group:Originalbefund hinzugefügt, NotariusSub auch als Teil von group:Formular
                 eingefügt; issuer, recipient auch in der Transkription zulässig (GV) 2006-07-05:
                 lang_MOM in mixed Type true umgewandelt (GV) 2006-06-27: verschiedene
                 Attribut-Korrekturen (GV) 2006-06-26: lang_MOM eingeführt. (GV) 2006-06-21:
                 teiHeader fakultativ, respStmt aus text/front herausgenommen (GV) 2006-06-16:
-                date_sort korrigiert, Attribut b_name zu &lt;text> eingeführt (GV) 2006-06-07:
+                date_sort korrigiert, Attribut b_name zu &lt;text&gt; eingeführt (GV) 2006-06-07:
                 issuer &amp; recipient nur in abstract zugelassen; subelemente von bibl entfernt; a
                 global definiert, appinfo zu settlement, repository und scope global definiert. (GV)
-                2006-05-21: Captions geändert und ein paar Sicherheits &lt;present>no eingefügt.
+                2006-05-21: Captions geändert und ein paar Sicherheits &lt;present&gt;no eingefügt.
                 (GV) 2006-05-18: sourceDescVolltext ergänzt und kleinere editMOM-Ergänzungen (GV)
                 2006-05-17: sourceDesc aufgeräumt; Versuch alle Elemente, die in die Maske kommen,
                 global zu definieren; note aus den Fließtexten geworfen. (GV) 2006-05-16: expan
-                statt abbr für Abkürzung, note/index als eigener Reiter, &lt;caption xml:lang="deu">
-                eingefügt; Attribute (z.B. id/n) mit &lt;present>no&lt;/present> versehen. Menü
-                "Siegelbeschreibung" ergänzt. &lt;sup> in p und abstract zugelassen, aber nicht in
+                statt abbr für Abkürzung, note/index als eigener Reiter, &lt;caption xml:lang="deu"&gt;
+                eingefügt; Attribute (z.B. id/n) mit &lt;present&gt;no&lt;/present&gt; versehen. Menü
+                "Siegelbeschreibung" ergänzt. &lt;sup&gt; in p und abstract zugelassen, aber nicht in
                 Menüs übernommen, denn diese Tags müssen noch nachbearbeitet werden. (GV) 2006-05-11
                 Einige Elemente, die in Fließtextfeldern auftauchen, global definiert (pTenor, a,
-                legend), in einigen Fällen &lt;present>no&lt;/present> eingefügt (group etc.) (GV)
+                legend), in einigen Fällen &lt;present&gt;no&lt;/present&gt; eingefügt (group etc.) (GV)
                 2006-05-09 Knoten, die selber nicht angezeigt werden und keine anzuzeigenden
-                Subknoten haben, sind mit dem Attribut &lt;present>no&lt;/present> in der
+                Subknoten haben, sind mit dem Attribut &lt;present&gt;no&lt;/present&gt; in der
                 EditMOM-appinfo versehen. Alle Elemente, die als Fließtext auftauchen können, sind
                 global definiert. (GV) 2006-05-02 listBibl (listBiblEdition, listBiblRegest,
                 listBiblFaksimile, listBiblErw), sourceDesc (sourceDescRegest), p (p, pTenor)
                 typisiert, um in der Anzeige differenzieren zu können. EditMOM:Auswahlliste
-                eingeführt. (GV) 2006-04-25 Weitere &lt;tab>-hinzugefügt. (GV) 2006-04-06 Innerhalb
+                eingeführt. (GV) 2006-04-25 Weitere &lt;tab&gt;-hinzugefügt. (GV) 2006-04-06 Innerhalb
                 von hi Formular zugelassen; issuer verzweigt wie persName, persName kann auch note
                 enthalten. Weitere Attributlisten plausibler aufgereiht. (GV) 2006-04-05 Reihenfolge
                 der Tenorelemente plausibler angeordnet, hi::target in hi::type korrigiert, ein paar
@@ -104,8 +100,7 @@
                                                 </xs:documentation>
                                             </xs:annotation>
                                             <xs:complexType>
-                                                <xs:sequence>
-                                                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:element ref="title"/>
                                                   <xs:element name="author">
                                                   <xs:annotation>
@@ -122,7 +117,6 @@
                                                   </xs:element>
                                                   <xs:element ref="p"/>
                                                   </xs:choice>
-                                                </xs:sequence>
                                                 <xs:attributeGroup ref="standard"/>
                                             </xs:complexType>
                                         </xs:element>
@@ -147,11 +141,9 @@
                                                 </xs:documentation>
                                             </xs:annotation>
                                             <xs:complexType>
-                                                <xs:sequence>
-                                                  <xs:choice minOccurs="0">
+                                                <xs:choice minOccurs="0">
                                                   <xs:element ref="p"/>
                                                   </xs:choice>
-                                                </xs:sequence>
                                                 <xs:attributeGroup ref="standard"/>
                                             </xs:complexType>
                                         </xs:element>
@@ -175,12 +167,10 @@
                                     </xs:documentation>
                                 </xs:annotation>
                                 <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
                                             <xs:element ref="p"/>
                                             <xs:element ref="respStmt"/>
                                         </xs:choice>
-                                    </xs:sequence>
                                     <xs:attributeGroup ref="standard"/>
                                 </xs:complexType>
                             </xs:element>
@@ -232,8 +222,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element name="publisher">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
@@ -301,7 +290,6 @@
                     <xs:group ref="date"/>
                     <xs:element ref="p"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -320,8 +308,7 @@
                 verlegerische Verantwortung </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="name"/>
                     <xs:element name="resp">
                         <xs:annotation>
@@ -351,7 +338,6 @@
                     </xs:element>
                     <xs:group ref="date"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -383,8 +369,7 @@
                             </xs:documentation>
                         </xs:annotation>
                         <xs:complexType mixed="true">
-                            <xs:sequence>
-                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                     <xs:element name="sourceDesc">
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
@@ -397,8 +382,7 @@
                                             </xs:appinfo>
                                         </xs:annotation>
                                         <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:element name="sourceDescRegest">
                                                   <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
@@ -475,7 +459,6 @@
                                                   </xs:annotation>
                                                   </xs:element>
                                                 </xs:choice>
-                                            </xs:sequence>
                                         </xs:complexType>
                                     </xs:element>
                                     <xs:element ref="publicationStmt">
@@ -495,7 +478,6 @@
                                         </xs:annotation>
                                     </xs:element>
                                 </xs:choice>
-                            </xs:sequence>
                         </xs:complexType>
                     </xs:element>
                     <xs:choice>
@@ -537,9 +519,7 @@
                                         <xs:element minOccurs="0" ref="tenor"/>
                                     </xs:sequence>
                                 </xs:choice>
-                                <xs:assert test="idno/text() != ''"
-                                    xpathDefaultNamespace="##targetNamespace"
-                                    xerces:message="i18n:charter-signature-required-message">
+                                <xs:assert test="idno/text() != ''" xpathDefaultNamespace="##targetNamespace" xerces:message="i18n:charter-signature-required-message">
                                     <xs:annotation>
                                         <xs:appinfo>
                                             <xrx:i18n>
@@ -566,12 +546,10 @@
                                     Texten als Teil eines Corpus z.B. </xs:documentation>
                             </xs:annotation>
                             <xs:complexType>
-                                <xs:sequence>
-                                    <xs:choice maxOccurs="unbounded">
+                                <xs:choice maxOccurs="unbounded">
                                         <xs:element ref="h1"/>
                                         <xs:element ref="text"/>
                                     </xs:choice>
-                                </xs:sequence>
                                 <xs:attributeGroup ref="standard"/>
                             </xs:complexType>
                         </xs:element>
@@ -585,8 +563,7 @@
                                 Register, Verzeichnisse) </xs:documentation>
                         </xs:annotation>
                         <xs:complexType>
-                            <xs:sequence>
-                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                     <xs:element ref="persName">
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
@@ -642,7 +619,6 @@
                                     </xs:element>
                                     <xs:element ref="divNotes"/>
                                 </xs:choice>
-                            </xs:sequence>
                         </xs:complexType>
                     </xs:element>
                 </xs:sequence>
@@ -675,11 +651,7 @@
                 Handschriftensignatur in einer Bibliothek. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:group ref="layout"/>
-                </xs:choice>
-            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
             <xs:attributeGroup ref="standard"/>
             <xs:attribute name="old"/>
         </xs:complexType>
@@ -701,8 +673,7 @@
                 charter</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="class"/>
                     <xs:element ref="abstract"/>
                     <xs:element name="issued" minOccurs="1" maxOccurs="1">
@@ -727,8 +698,7 @@
                                     <xrxe:mixed>false</xrxe:mixed>
                                 </xs:appinfo>
                             </xs:annotation>
-                            <xs:sequence>
-                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                     <xs:element ref="placeName">
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
@@ -756,8 +726,8 @@
                                                   <xrx:example>
                                                   <xrx:i18n>
                                                   <xrx:key>cei_issued_date_example</xrx:key>
-                                                  <xrx:default>&lt;cei:date value="16091001">1609
-                                                  Oktober 1&lt;/cei:date></xrx:default>
+                                                  <xrx:default>&lt;cei:date value="16091001"&gt;1609
+                                                  Oktober 1&lt;/cei:date&gt;</xrx:default>
                                                   </xrx:i18n>
                                                   </xrx:example>
                                                 </xs:documentation>
@@ -773,12 +743,8 @@
                                         </xs:element>
                                     </xs:choice>
                                 </xs:choice>
-                            </xs:sequence>
                             <xs:attributeGroup ref="standard"/>
-                            <xs:assert
-                                test="(matches(string(date/@value), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and date) or not(date)"
-                                xpathDefaultNamespace="##targetNamespace"
-                                xerces:message="i18n:wrong-date-format-message">
+                            <xs:assert test="(matches(string(date/@value), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and date) or not(date)" xpathDefaultNamespace="##targetNamespace" xerces:message="i18n:wrong-date-format-message">
                                 <xs:annotation>
                                     <xs:appinfo>
                                         <xrx:i18n>
@@ -789,10 +755,7 @@
                                     </xs:appinfo>
                                 </xs:annotation>
                             </xs:assert>
-                            <xs:assert
-                                test="(matches(string(dateRange/@from), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and dateRange) or not(dateRange)"
-                                xpathDefaultNamespace="##targetNamespace"
-                                xerces:message="i18n:wrong-date-format-message">
+                            <xs:assert test="(matches(string(dateRange/@from), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and dateRange) or not(dateRange)" xpathDefaultNamespace="##targetNamespace" xerces:message="i18n:wrong-date-format-message">
                                 <xs:annotation>
                                     <xs:appinfo>
                                         <xrx:i18n>
@@ -803,10 +766,7 @@
                                     </xs:appinfo>
                                 </xs:annotation>
                             </xs:assert>
-                            <xs:assert
-                                test="(matches(string(dateRange/@to), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and dateRange) or not(dateRange)"
-                                xpathDefaultNamespace="##targetNamespace"
-                                xerces:message="i18n:wrong-date-format-message">
+                            <xs:assert test="(matches(string(dateRange/@to), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and dateRange) or not(dateRange)" xpathDefaultNamespace="##targetNamespace" xerces:message="i18n:wrong-date-format-message">
                                 <xs:annotation>
                                     <xs:appinfo>
                                         <xrx:i18n>
@@ -834,8 +794,7 @@
                             </xs:appinfo>
                         </xs:annotation>
                         <xs:complexType mixed="true">
-                            <xs:sequence>
-                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                     <xs:element ref="traditioForm">
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
@@ -861,7 +820,6 @@
                                     <xs:element ref="p"/>
                                     <!--Erweiterung-->
                                 </xs:choice>
-                            </xs:sequence>
                             <xs:attributeGroup ref="certainty"/>
                             <xs:attribute name="type" type="xs:anySimpleType" use="optional"/>
                             <xs:attribute name="sigil" type="xs:anySimpleType">
@@ -895,8 +853,7 @@
                             </xs:documentation>
                         </xs:annotation>
                         <xs:complexType mixed="true">
-                            <xs:sequence>
-                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                     <xs:element name="listBibl">
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
@@ -913,14 +870,12 @@
                                                 Urkunde betreffen.. </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:choice>
                                                   <xs:element minOccurs="0" ref="ref"/>
                                                   <xs:element ref="bibl"/>
                                                   </xs:choice>
                                                 </xs:choice>
-                                            </xs:sequence>
                                             <xs:attribute name="type"/>
                                             <!--Erweiterung-->
                                             <xs:attributeGroup ref="standard"/>
@@ -942,14 +897,12 @@
                                             </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:choice>
                                                   <xs:element minOccurs="0" ref="ref"/>
                                                   <xs:element ref="bibl"/>
                                                   </xs:choice>
                                                 </xs:choice>
-                                            </xs:sequence>
                                             <xs:attributeGroup ref="standard"/>
                                         </xs:complexType>
                                     </xs:element>
@@ -969,14 +922,12 @@
                                             </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:choice>
                                                   <xs:element minOccurs="0" ref="ref"/>
                                                   <xs:element ref="bibl"/>
                                                   </xs:choice>
                                                 </xs:choice>
-                                            </xs:sequence>
                                             <xs:attributeGroup ref="standard"/>
                                         </xs:complexType>
                                     </xs:element>
@@ -996,14 +947,12 @@
                                                 type="facsimilia" </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:choice>
                                                   <xs:element minOccurs="0" ref="ref"/>
                                                   <xs:element ref="bibl"/>
                                                   </xs:choice>
                                                 </xs:choice>
-                                            </xs:sequence>
                                             <xs:attributeGroup ref="standard"/>
                                         </xs:complexType>
                                     </xs:element>
@@ -1023,14 +972,12 @@
                                             </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:choice>
                                                   <xs:element minOccurs="0" ref="ref"/>
                                                   <xs:element ref="bibl"/>
                                                   </xs:choice>
                                                 </xs:choice>
-                                            </xs:sequence>
                                             <xs:attributeGroup ref="standard"/>
                                         </xs:complexType>
                                     </xs:element>
@@ -1047,7 +994,6 @@
                                     <xs:element ref="incipit"/>
                                     <xs:element ref="divNotes"/>
                                 </xs:choice>
-                            </xs:sequence>
                             <xs:attributeGroup ref="standard"/>
                         </xs:complexType>
                     </xs:element>
@@ -1073,7 +1019,6 @@
                         </xs:complexType>
                     </xs:element>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1103,25 +1048,23 @@
                 <xrx:example>
                     <xrx:i18n>
                         <xrx:key>cei_abstract_example</xrx:key>
-                        <xrx:default>&lt;cei:abstract>&lt;cei:issuer>Rudolph III. Herzog von
-                            Österreich&lt;/cei:issuer> bestätigt die Privilegien des
-                            &lt;cei:recipient>Klosters Geras&lt;/cei:recipient>, namentlich in
+                        <xrx:default>&lt;cei:abstract&gt;&lt;cei:issuer&gt;Rudolph III. Herzog von
+                            Österreich&lt;/cei:issuer&gt; bestätigt die Privilegien des
+                            &lt;cei:recipient&gt;Klosters Geras&lt;/cei:recipient&gt;, namentlich in
                             gewissen Beziehungen, in denen Beeinträchtigungen eingetreten
-                            waren.&lt;/cei:abstract></xrx:default>
+                            waren.&lt;/cei:abstract&gt;</xrx:default>
                     </xrx:i18n>
                 </xrx:example>
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="class"/>
                     <xs:group ref="Sachliches"/>
                     <xs:group ref="layout"/>
                     <xs:element ref="recipient"/>
                     <xs:element ref="issuer"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1156,12 +1099,10 @@
                         </xs:appinfo>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:group ref="layout"/>
                                 <xs:group ref="biblArch"/>
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1178,12 +1119,10 @@
                         </xs:appinfo>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:element ref="ref"/>
                                 <xs:element ref="bibl"/>
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1202,11 +1141,9 @@
                         </xs:appinfo>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:element ref="desc"/>
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1317,11 +1254,9 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="witness"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1342,8 +1277,7 @@
             <xs:documentation xml:lang="deu"> Der einzelne Textzeuge </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="traditioForm">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
@@ -1363,7 +1297,6 @@
                     <xs:group ref="layout"/>
                     <xs:group ref="textualElements"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="id"/>
             <xs:attribute name="n" type="xs:anySimpleType">
@@ -1397,11 +1330,7 @@
                 entnehmen oder in der profileDesc zu dokumentieren. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:group ref="layout"/>
-                </xs:choice>
-            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1420,12 +1349,7 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:group ref="layout"/>
-                </xs:choice>
-            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element ref="foreign"/><xs:group ref="layout"/></xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1442,11 +1366,9 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="index"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1468,14 +1390,12 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="notariusDesc"/>
                     <xs:element ref="sealDesc"/>
                     <xs:element ref="subscriptio"/>
                     <xs:element ref="chirograph"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1497,14 +1417,12 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="seal"/>
                     <xs:element ref="legend"/>
                     <xs:group ref="layout"/>
                     <xs:element ref="index"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1531,8 +1449,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="layout"/>
                     <xs:element ref="sigillant"/>
                     <xs:element ref="legend"/>
@@ -1541,7 +1458,6 @@
                     <xs:element ref="sealCondition"/>
                     <xs:element ref="index"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1568,11 +1484,9 @@
                 wieder. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="place"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1599,12 +1513,10 @@
             <xs:documentation xml:lang="deu"> der Siegelinhaber </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="quote"/>
                     <xs:group ref="Sachauszeichnung"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="reg"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1625,8 +1537,7 @@
                 Unterfertigung.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="notariusSub">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
@@ -1648,7 +1559,6 @@
                     <xs:element ref="index"/>
                     <xs:element ref="num"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1700,12 +1610,10 @@
                 preserving archives or the recipient. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attribute name="position" type="xs:anySimpleType" use="optional"/>
             <xs:attributeGroup ref="lang"/>
@@ -1732,12 +1640,10 @@
                 "type" specifies if it refers to specific part of the text.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1759,14 +1665,12 @@
                 Beschreibstoff (material), Maße (dimensions) etc. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="material"/>
                     <xs:element ref="dimensions"/>
                     <xs:element ref="condition"/>
                     <xs:element ref="decoDesc"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1786,11 +1690,9 @@
                 Beschreibung</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="p"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="reference"/>
         </xs:complexType>
     </xs:element>
@@ -1810,9 +1712,7 @@
                 Elementen) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:element name="width" type="xs:string">
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element name="width" type="xs:string">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
                                 <xrxe:label>
@@ -1829,8 +1729,7 @@
                                 </xrxe:menu-item>
                             </xs:appinfo>
                         </xs:annotation>
-                    </xs:element>
-                    <xs:element name="height" type="xs:string">
+                    </xs:element><xs:element name="height" type="xs:string">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
                                 <xrxe:label>
@@ -1847,8 +1746,7 @@
                                 </xrxe:menu-item>
                             </xs:appinfo>
                         </xs:annotation>
-                    </xs:element>
-                    <xs:element name="plica" type="xs:string">
+                    </xs:element><xs:element name="plica" type="xs:string">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
                                 <xrxe:label>
@@ -1867,9 +1765,7 @@
                             <xs:documentation xml:lang="eng"> describes the depth of the fold used
                                 to secure the threads for the seal </xs:documentation>
                         </xs:annotation>
-                    </xs:element>
-                </xs:choice>
-            </xs:sequence>
+                    </xs:element></xs:choice>
             <xs:attributeGroup ref="standard"/>
             <xs:attribute name="type" type="xs:string"/>
             <!--Erweiterung-->
@@ -1920,12 +1816,7 @@
                 written </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:group ref="layout"/>
-                </xs:choice>
-            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element ref="foreign"/><xs:group ref="layout"/></xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1977,12 +1868,10 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attribute name="position" type="xs:anySimpleType" use="optional"/>
             <xs:attributeGroup ref="lang"/>
@@ -2011,8 +1900,7 @@
                 Archivale (mit Lagerort, Signatur etc.) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="settlement"/>
                     <xs:element ref="region"/>
                     <xs:element ref="country"/>
@@ -2026,7 +1914,6 @@
                     <xs:element ref="altIdentifier"/>
                     <xs:element ref="hi"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2045,8 +1932,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:choice>
                         <xs:element ref="settlement"/>
                         <xs:element ref="region"/>
@@ -2060,7 +1946,6 @@
                     <xs:element ref="scope"/>
                     <xs:element ref="note"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
             <xs:attributeGroup ref="type"/>
         </xs:complexType>
@@ -2086,11 +1971,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:group ref="layout"/>
-                </xs:choice>
-            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
             <xs:attributeGroup ref="expan"/>
             <xs:attributeGroup ref="key"/>
             <xs:attributeGroup ref="lang"/>
@@ -2169,8 +2050,7 @@
                 Signatur/Bezeichnung innerhalb der lagernden Institution. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="settlement"/>
                     <xs:element ref="region"/>
                     <xs:element ref="country"/>
@@ -2178,7 +2058,6 @@
                     <xs:element ref="idno"/>
                     <xs:element ref="scope"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2256,13 +2135,11 @@
                 type="Originaldatierung" </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:element ref="num"/>
                     <xs:element ref="note"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2283,14 +2160,12 @@
                 Transkriptionselemente</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:group ref="Formular"/>
                     <xs:element ref="pTenor"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -2314,8 +2189,7 @@
             <xs:documentation xml:lang="deu">Ein Absatz mit Fließtext </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="archIdentifier"/>
                     <xs:element ref="msIdentifier"/>
@@ -2328,7 +2202,6 @@
                     <xs:element ref="scope"/>
                     <!--Erweiterung-->
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="resp"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2359,15 +2232,13 @@
             <xs:documentation xml:lang="deu">Ein Absatz </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Formular"/>
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="recipient"/>
                     <xs:element ref="issuer"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2415,13 +2286,11 @@
                 Gottes</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2449,13 +2318,11 @@
                 Titeln</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2482,13 +2349,11 @@
             <xs:documentation xml:lang="deu">Eine Adresse im Urkundentext</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2515,13 +2380,11 @@
             <xs:documentation xml:lang="deu">Die Veröffentlichungsformel</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2549,13 +2412,11 @@
                 Urkunde begründet </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2583,15 +2444,13 @@
                 Ausstellung der Urkunde vorangegangen sind </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="rogatio"/>
                     <xs:element ref="intercessio"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2619,13 +2478,11 @@
                 (cf. VID n. 326 http://www.cei.lmu.de/VID/VID.php?326)</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2653,13 +2510,11 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2687,13 +2542,11 @@
                 Rechtsverfügungen</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2720,13 +2573,11 @@
             <xs:documentation xml:lang="deu">kündigt die Beglaubigungsmittel an</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2754,12 +2605,10 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2787,14 +2636,12 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element minOccurs="0" maxOccurs="unbounded" ref="setPhrase"/>
                     <xs:element minOccurs="0" maxOccurs="unbounded" ref="notariusSub"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type">
                 <xs:annotation>
                     <xs:documentation xml:lang="deu"> Die Unterscheidung in "Signumzeile",
@@ -2828,13 +2675,11 @@
             <xs:documentation xml:lang="deu">Datierung der Urkunde </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2854,13 +2699,11 @@
                 Floskel</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2891,12 +2734,10 @@
                 des "Vocabulaire Internationale de Diplomatique" orientieren. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2925,12 +2766,10 @@
             <xs:documentation xml:lang="deu">Die Notarsunterschrift </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3056,8 +2895,7 @@
                 machen. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
@@ -3071,7 +2909,6 @@
                     <!--Erweiterung-->
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="extent" type="xs:anySimpleType"/>
             <xs:attribute name="degree" type="xs:anySimpleType">
                 <xs:annotation>
@@ -3125,8 +2962,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
@@ -3134,7 +2970,6 @@
                     <xs:element ref="handShift"/>
                     <xs:element ref="pict"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="extent" type="xs:anySimpleType">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -3249,8 +3084,7 @@
                             Version.</xs:documentation>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:group ref="Sachauszeichnung"/>
                                 <xs:group ref="biblArch"/>
                                 <xs:group ref="layout"/>
@@ -3267,7 +3101,6 @@
                                 <xs:element ref="supplied"/>
                                 <!--Erweiterung-->
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attributeGroup ref="wit"/>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
@@ -3285,8 +3118,7 @@
                         <xs:documentation xml:lang="eng">reading </xs:documentation>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:element ref="w"/>
                                 <!--Erweiterung-->
                                 <xs:element ref="add"/>
@@ -3299,7 +3131,6 @@
                                 <xs:group ref="layout"/>
                                 <xs:group ref="reference"/>
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attribute name="type"/>
                         <!--Erweiterung-->
                         <xs:attributeGroup ref="wit"/>
@@ -3332,8 +3163,7 @@
                 Abkürzung.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
                     <xs:element ref="pb"/>
@@ -3342,7 +3172,6 @@
                     <xs:element ref="sic"/>
                     <xs:element ref="damage"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="abbr">
                 <xs:annotation>
@@ -3376,8 +3205,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
@@ -3386,7 +3214,6 @@
                     <xs:element ref="handShift"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="corr">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -3419,8 +3246,7 @@
                 und dann mit dem Inhalt des Elements korrigiert worden ist. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="sic"/>
                     <xs:element ref="lb"/>
@@ -3431,7 +3257,6 @@
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="sic"/>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
@@ -3460,8 +3285,7 @@
                 ist (z.B. durch Durchstreichen, Unterpunkten, Rasur). </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="add"/>
                     <xs:element ref="supplied"/>
@@ -3472,7 +3296,6 @@
                     <xs:element ref="sic"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3499,8 +3322,7 @@
                 Text ersetzen. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
@@ -3515,7 +3337,6 @@
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="status"/>
             <!--Erweiterung-->
             <xs:attributeGroup ref="transcription"/>
@@ -3545,8 +3366,7 @@
                 dokumentiert ist, durch den Editor. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
                     <xs:element ref="pb"/>
@@ -3559,7 +3379,6 @@
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -3791,13 +3610,11 @@
                 Texte, Texte zwischen Referenzpunkten, Elongata </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:group ref="Formular"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="rend"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3936,15 +3753,13 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="bibl"/>
                     <xs:element ref="archIdentifier"/>
                     <xs:element ref="msIdentifier"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="place"/>
             <xs:attributeGroup ref="id"/>
             <xs:attributeGroup ref="type"/>
@@ -4059,11 +3874,9 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="textualElements"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4082,11 +3895,9 @@
             <xs:documentation xml:lang="deu">Enthält die Fußnoten zur Urkunde.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="note"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -4114,12 +3925,10 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachauszeichnung"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4184,14 +3993,12 @@
                 Urkunde unseres Vaters die folgenden Wortlaut hat: .... </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="reference"/>
                     <xs:element ref="foreign"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -4268,12 +4075,10 @@
             <xs:documentation xml:lang="deu">Ein Listenpunkt </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -4312,13 +4117,11 @@
                 einer Maßangabe besteht. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="num"/>
                     <xs:element ref="index"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -4345,14 +4148,12 @@
             <xs:documentation xml:lang="deu">Eine Zahlenangabe </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="w"/>
                     <!--Erweiterung-->
                     <xs:element ref="pc"/>
                     <!--Erweiterung-->
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attribute name="value" type="xs:double"/>
             <xs:attributeGroup ref="lang"/>
@@ -4418,13 +4219,11 @@
                 Stichwörtern (Register, Index) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="ref"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="indexName">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -4491,13 +4290,11 @@
             <xs:documentation xml:lang="deu"> Die Angabe eines spezifischen Tages in einem Kalender
                 (=Datumsangabe). </xs:documentation>
         </xs:annotation>
-        <xs:alternative test="ancestor::issued" type="dateNormalized"
-            xpathDefaultNamespace="##targetNamespace"/>
+        <xs:alternative test="ancestor::issued" type="dateNormalized" xpathDefaultNamespace="##targetNamespace"/>
         <xs:alternative type="date" xpathDefaultNamespace="##targetNamespace"/>
     </xs:element>
     <xs:complexType name="dateGeneral" mixed="true">
-        <xs:sequence>
-            <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element ref="foreign"/>
                 <xs:element ref="num"/>
                 <xs:group ref="Originalbefund"/>
@@ -4505,7 +4302,6 @@
                 <xs:element ref="figure"/>
                 <!--Erweiterung-->
             </xs:choice>
-        </xs:sequence>
         <xs:attributeGroup ref="lang"/>
         <xs:attributeGroup ref="standard"/>
     </xs:complexType>
@@ -4545,13 +4341,11 @@
                 zutreffenden Datums in den Attributen "from" und "to" </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="num"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="from" type="normalizedDateValue" use="required">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -4633,8 +4427,7 @@
             <xs:documentation xml:lang="deu">Die Bezeichnung einer Organisation</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:choice>
                         <xs:annotation>
                             <xs:documentation xml:lang="deu">Geographische Angaben
@@ -4648,7 +4441,6 @@
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="identification"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
@@ -4675,8 +4467,7 @@
             <xs:documentation xml:lang="deu">ein Personenname </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:choice>
                         <xs:annotation>
                             <xs:documentation xml:lang="deu">Geographische Angaben
@@ -4694,7 +4485,6 @@
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="identification"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
@@ -4721,13 +4511,11 @@
             <xs:documentation xml:lang="deu">ein Vorname</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4754,8 +4542,7 @@
                 Unterscheidung einer Person z.B. durch Gruppenzuordnung dient.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="rolename"/>
                     <xs:choice>
                         <xs:annotation>
@@ -4771,7 +4558,6 @@
                     <!--Erweiterung-->
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4798,15 +4584,13 @@
                 ...</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachauszeichnung"/>
                     <!--Erweiterung-->
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4836,8 +4620,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="persName"/>
                     <xs:element ref="orgName"/>
@@ -4851,7 +4634,6 @@
                     </xs:choice>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4880,8 +4662,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="persName"/>
                     <xs:element ref="orgName"/>
                     <xs:choice>
@@ -4896,7 +4677,6 @@
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4922,8 +4702,7 @@
             <xs:documentation xml:lang="deu">Ein einzelner Zeuge. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:group ref="Originalbefund"/>
                     <xs:choice>
@@ -4936,7 +4715,6 @@
                     </xs:choice>
                     <xs:element ref="persName"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -5047,8 +4825,7 @@
                 Klöster, Burgen, Bundesländer, Herrschaften, Staaten etc. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="index"/>
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
@@ -5058,7 +4835,6 @@
                     <!--Erweiterung-->
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="key"/>
             <xs:attributeGroup ref="geog"/>
             <xs:attributeGroup ref="type"/>
@@ -5089,13 +4865,11 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="geog"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
@@ -5156,8 +4930,7 @@
                         </xs:appinfo>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:element ref="scope"/>
                                 <xs:element name="pubPlace">
                                     <xs:complexType>
@@ -5170,7 +4943,6 @@
                                 </xs:element>
                                 <xs:group ref="date"/>
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -5240,15 +5012,13 @@
             <xs:documentation xml:lang="eng">Bibliographic informations</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="layout"/>
                     <xs:element ref="foreign"/>
                     <xs:element ref="quote"/>
                     <xs:group ref="Referenz"/>
                     <xs:group ref="BibliographicInformation"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="status"/>
             <!--Erweiterung-->
             <xs:attribute name="type"/>
@@ -5394,9 +5164,7 @@
                             <xrx:default>certainty</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant
-                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"
-                    />
+                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"/>
                 </xs:appinfo>
                 <xs:documentation xml:lang="deu"> Für Genauigkeitsangaben z.B. bei Datierungen,
                     werden mit Schlüsselwörtern (zu benennen in der encodingDesc) oder kurzen
@@ -5432,9 +5200,7 @@
                             <xrx:default>reg</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant
-                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"
-                    />
+                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"/>
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
@@ -5465,9 +5231,7 @@
                             <xrx:default>type</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant
-                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"
-                    />
+                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"/>
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>

--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -1,4 +1,10 @@
-<?xml version="1.0" encoding="UTF-8"?><xs:schema xmlns="http://www.monasterium.net/NS/cei" xmlns:xerces="http://xerces.apache.org" xmlns:xrxe="http://www.monasterium.net/NS/xrxe" xmlns:xrx="http://www.monasterium.net/NS/xrx" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.monasterium.net/NS/cei" id="cei" vc:minVersion="1.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://www.monasterium.net/NS/cei" xmlns:xerces="http://xerces.apache.org"
+    xmlns:xrxe="http://www.monasterium.net/NS/xrxe" xmlns:xrx="http://www.monasterium.net/NS/xrx"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" attributeFormDefault="unqualified"
+    elementFormDefault="qualified" targetNamespace="http://www.monasterium.net/NS/cei" id="cei"
+    vc:minVersion="1.1">
     <xs:element name="cei">
         <xs:annotation>
             <xs:documentation xml:lang="deu"> Wurzelelement für alle Dokumente, die den Regeln der
@@ -36,22 +42,23 @@
                 (GV) 2006-05-18: sourceDescVolltext ergänzt und kleinere editMOM-Ergänzungen (GV)
                 2006-05-17: sourceDesc aufgeräumt; Versuch alle Elemente, die in die Maske kommen,
                 global zu definieren; note aus den Fließtexten geworfen. (GV) 2006-05-16: expan
-                statt abbr für Abkürzung, note/index als eigener Reiter, &lt;caption xml:lang="deu"&gt;
-                eingefügt; Attribute (z.B. id/n) mit &lt;present&gt;no&lt;/present&gt; versehen. Menü
-                "Siegelbeschreibung" ergänzt. &lt;sup&gt; in p und abstract zugelassen, aber nicht in
-                Menüs übernommen, denn diese Tags müssen noch nachbearbeitet werden. (GV) 2006-05-11
-                Einige Elemente, die in Fließtextfeldern auftauchen, global definiert (pTenor, a,
-                legend), in einigen Fällen &lt;present&gt;no&lt;/present&gt; eingefügt (group etc.) (GV)
-                2006-05-09 Knoten, die selber nicht angezeigt werden und keine anzuzeigenden
-                Subknoten haben, sind mit dem Attribut &lt;present&gt;no&lt;/present&gt; in der
-                EditMOM-appinfo versehen. Alle Elemente, die als Fließtext auftauchen können, sind
-                global definiert. (GV) 2006-05-02 listBibl (listBiblEdition, listBiblRegest,
-                listBiblFaksimile, listBiblErw), sourceDesc (sourceDescRegest), p (p, pTenor)
-                typisiert, um in der Anzeige differenzieren zu können. EditMOM:Auswahlliste
-                eingeführt. (GV) 2006-04-25 Weitere &lt;tab&gt;-hinzugefügt. (GV) 2006-04-06 Innerhalb
-                von hi Formular zugelassen; issuer verzweigt wie persName, persName kann auch note
-                enthalten. Weitere Attributlisten plausibler aufgereiht. (GV) 2006-04-05 Reihenfolge
-                der Tenorelemente plausibler angeordnet, hi::target in hi::type korrigiert, ein paar
+                statt abbr für Abkürzung, note/index als eigener Reiter, &lt;caption
+                xml:lang="deu"&gt; eingefügt; Attribute (z.B. id/n) mit
+                &lt;present&gt;no&lt;/present&gt; versehen. Menü "Siegelbeschreibung" ergänzt.
+                &lt;sup&gt; in p und abstract zugelassen, aber nicht in Menüs übernommen, denn diese
+                Tags müssen noch nachbearbeitet werden. (GV) 2006-05-11 Einige Elemente, die in
+                Fließtextfeldern auftauchen, global definiert (pTenor, a, legend), in einigen Fällen
+                &lt;present&gt;no&lt;/present&gt; eingefügt (group etc.) (GV) 2006-05-09 Knoten, die
+                selber nicht angezeigt werden und keine anzuzeigenden Subknoten haben, sind mit dem
+                Attribut &lt;present&gt;no&lt;/present&gt; in der EditMOM-appinfo versehen. Alle
+                Elemente, die als Fließtext auftauchen können, sind global definiert. (GV)
+                2006-05-02 listBibl (listBiblEdition, listBiblRegest, listBiblFaksimile,
+                listBiblErw), sourceDesc (sourceDescRegest), p (p, pTenor) typisiert, um in der
+                Anzeige differenzieren zu können. EditMOM:Auswahlliste eingeführt. (GV) 2006-04-25
+                Weitere &lt;tab&gt;-hinzugefügt. (GV) 2006-04-06 Innerhalb von hi Formular
+                zugelassen; issuer verzweigt wie persName, persName kann auch note enthalten.
+                Weitere Attributlisten plausibler aufgereiht. (GV) 2006-04-05 Reihenfolge der
+                Tenorelemente plausibler angeordnet, hi::target in hi::type korrigiert, ein paar
                 Attributlisten plausibler aufgereiht. (GV) 2006-03-28 p aus dem Originalbefund
                 direkt unterhalb von tenor verschoben, um sachlich fehlerhafte Rekursionen zu
                 vermeiden (GV) 2006-03-19 (Ausgangsversion) </xs:documentation>
@@ -116,7 +123,7 @@
                                                   </xs:annotation>
                                                   </xs:element>
                                                   <xs:element ref="p"/>
-                                                  </xs:choice>
+                                                </xs:choice>
                                                 <xs:attributeGroup ref="standard"/>
                                             </xs:complexType>
                                         </xs:element>
@@ -143,7 +150,7 @@
                                             <xs:complexType>
                                                 <xs:choice minOccurs="0">
                                                   <xs:element ref="p"/>
-                                                  </xs:choice>
+                                                </xs:choice>
                                                 <xs:attributeGroup ref="standard"/>
                                             </xs:complexType>
                                         </xs:element>
@@ -168,9 +175,9 @@
                                 </xs:annotation>
                                 <xs:complexType>
                                     <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                            <xs:element ref="p"/>
-                                            <xs:element ref="respStmt"/>
-                                        </xs:choice>
+                                        <xs:element ref="p"/>
+                                        <xs:element ref="respStmt"/>
+                                    </xs:choice>
                                     <xs:attributeGroup ref="standard"/>
                                 </xs:complexType>
                             </xs:element>
@@ -223,73 +230,72 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element name="publisher">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_publisher</xrx:key>
-                                        <xrx:default>publisher</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:relevant>false</xrxe:relevant>
-                            </xs:appinfo>
-                        </xs:annotation>
-                        <xs:complexType>
-                            <xs:simpleContent>
-                                <xs:extension base="xs:anySimpleType">
-                                    <xs:attributeGroup ref="standard"/>
-                                </xs:extension>
-                            </xs:simpleContent>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="pubPlace">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_pubPlace</xrx:key>
-                                        <xrx:default>pubPlace</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:relevant>false</xrxe:relevant>
-                            </xs:appinfo>
-                            <xs:documentation xml:lang="deu">Ort der
-                                Veröffentlichung</xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType>
-                            <xs:simpleContent>
-                                <xs:extension base="xs:anySimpleType">
-                                    <xs:attributeGroup ref="standard"/>
-                                </xs:extension>
-                            </xs:simpleContent>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="availability">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_availability</xrx:key>
-                                        <xrx:default>availability</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:relevant>false</xrxe:relevant>
-                            </xs:appinfo>
-                            <xs:documentation xml:lang="deu"> Verfügbarkeit und insbesondere ihre
-                                Einschränkungen ("restricted") </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType mixed="true">
-                            <xs:sequence>
-                                <xs:element ref="p" minOccurs="0"/>
-                            </xs:sequence>
-                            <xs:attribute name="status" type="xs:anySimpleType"/>
-                            <xs:attributeGroup ref="standard"/>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:group ref="date"/>
-                    <xs:element ref="p"/>
-                </xs:choice>
+                <xs:element name="publisher">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_publisher</xrx:key>
+                                    <xrx:default>publisher</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:relevant>false</xrxe:relevant>
+                        </xs:appinfo>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:simpleContent>
+                            <xs:extension base="xs:anySimpleType">
+                                <xs:attributeGroup ref="standard"/>
+                            </xs:extension>
+                        </xs:simpleContent>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="pubPlace">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_pubPlace</xrx:key>
+                                    <xrx:default>pubPlace</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:relevant>false</xrxe:relevant>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="deu">Ort der Veröffentlichung</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:simpleContent>
+                            <xs:extension base="xs:anySimpleType">
+                                <xs:attributeGroup ref="standard"/>
+                            </xs:extension>
+                        </xs:simpleContent>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="availability">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_availability</xrx:key>
+                                    <xrx:default>availability</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:relevant>false</xrxe:relevant>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="deu"> Verfügbarkeit und insbesondere ihre
+                            Einschränkungen ("restricted") </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType mixed="true">
+                        <xs:sequence>
+                            <xs:element ref="p" minOccurs="0"/>
+                        </xs:sequence>
+                        <xs:attribute name="status" type="xs:anySimpleType"/>
+                        <xs:attributeGroup ref="standard"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:group ref="date"/>
+                <xs:element ref="p"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -309,35 +315,34 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="name"/>
-                    <xs:element name="resp">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_resp</xrx:key>
-                                        <xrx:default>resp</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:relevant>false</xrxe:relevant>
-                            </xs:appinfo>
-                            <xs:documentation xml:lang="deu"> beschreibt die intellektuelle
-                                Verantwortlichkeit einer Person </xs:documentation>
-                            <xs:documentation xml:lang="eng"> contains a phrase describing the
-                                nature of a person's intellectual responsibility.
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType>
-                            <xs:simpleContent>
-                                <xs:extension base="xs:string">
-                                    <xs:attributeGroup ref="identification"/>
-                                    <xs:attributeGroup ref="standard"/>
-                                </xs:extension>
-                            </xs:simpleContent>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:group ref="date"/>
-                </xs:choice>
+                <xs:element ref="name"/>
+                <xs:element name="resp">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_resp</xrx:key>
+                                    <xrx:default>resp</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:relevant>false</xrxe:relevant>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="deu"> beschreibt die intellektuelle
+                            Verantwortlichkeit einer Person </xs:documentation>
+                        <xs:documentation xml:lang="eng"> contains a phrase describing the nature of
+                            a person's intellectual responsibility. </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:simpleContent>
+                            <xs:extension base="xs:string">
+                                <xs:attributeGroup ref="identification"/>
+                                <xs:attributeGroup ref="standard"/>
+                            </xs:extension>
+                        </xs:simpleContent>
+                    </xs:complexType>
+                </xs:element>
+                <xs:group ref="date"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -370,21 +375,21 @@
                         </xs:annotation>
                         <xs:complexType mixed="true">
                             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xs:element name="sourceDesc">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
+                                <xs:element name="sourceDesc">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:label>
+                                                <xrx:i18n>
                                                   <xrx:key>cei_sourceDesc</xrx:key>
                                                   <xrx:default>sourceDesc</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                        <xs:complexType>
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:element name="sourceDescRegest">
-                                                  <xs:annotation>
+                                                </xrx:i18n>
+                                            </xrxe:label>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                    <xs:complexType>
+                                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element name="sourceDescRegest">
+                                                <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
                                                   <xrxe:label>
                                                   <xrx:i18n>
@@ -397,8 +402,8 @@
                                                   CEI_MOM-spezifisch: Eigentlich eine SourceDesc,
                                                   die über ein Schlüsselwort "Regest" auf die Quelle
                                                   des Regests verweist. </xs:documentation>
-                                                  </xs:annotation>
-                                                  <xs:complexType>
+                                                </xs:annotation>
+                                                <xs:complexType>
                                                   <xs:sequence>
                                                   <xs:element maxOccurs="unbounded" ref="bibl">
                                                   <xs:annotation>
@@ -415,10 +420,10 @@
                                                   </xs:annotation>
                                                   </xs:attribute>
                                                   <xs:attributeGroup ref="standard"/>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  <xs:element name="sourceDescVolltext">
-                                                  <xs:annotation>
+                                                </xs:complexType>
+                                            </xs:element>
+                                            <xs:element name="sourceDescVolltext">
+                                                <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
                                                   <xrxe:label>
                                                   <xrx:i18n>
@@ -431,8 +436,8 @@
                                                   CEI_MOM-spezifisch: Eigentlich eine SourceDesc,
                                                   die über ein Schlüsselwort "Volltext" auf die
                                                   Quelle des Regests verweist. </xs:documentation>
-                                                  </xs:annotation>
-                                                  <xs:complexType>
+                                                </xs:annotation>
+                                                <xs:complexType>
                                                   <xs:sequence>
                                                   <xs:element maxOccurs="unbounded" ref="bibl">
                                                   <xs:annotation>
@@ -449,35 +454,35 @@
                                                   </xs:annotation>
                                                   </xs:attribute>
                                                   <xs:attributeGroup ref="standard"/>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  <xs:element ref="p">
-                                                  <xs:annotation>
+                                                </xs:complexType>
+                                            </xs:element>
+                                            <xs:element ref="p">
+                                                <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
                                                   <xrxe:relevant>false</xrxe:relevant>
                                                   </xs:appinfo>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                </xs:choice>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element ref="publicationStmt">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:relevant>false</xrxe:relevant>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:group ref="textualElements"/>
-                                    <xs:group ref="reference"/>
-                                    <xs:element ref="provenance">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:relevant>false</xrxe:relevant>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                </xs:choice>
+                                                </xs:annotation>
+                                            </xs:element>
+                                        </xs:choice>
+                                    </xs:complexType>
+                                </xs:element>
+                                <xs:element ref="publicationStmt">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:relevant>false</xrxe:relevant>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:group ref="textualElements"/>
+                                <xs:group ref="reference"/>
+                                <xs:element ref="provenance">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:relevant>false</xrxe:relevant>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                            </xs:choice>
                         </xs:complexType>
                     </xs:element>
                     <xs:choice>
@@ -519,7 +524,9 @@
                                         <xs:element minOccurs="0" ref="tenor"/>
                                     </xs:sequence>
                                 </xs:choice>
-                                <xs:assert test="idno/text() != ''" xpathDefaultNamespace="##targetNamespace" xerces:message="i18n:charter-signature-required-message">
+                                <xs:assert test="idno/text() != ''"
+                                    xpathDefaultNamespace="##targetNamespace"
+                                    xerces:message="i18n:charter-signature-required-message">
                                     <xs:annotation>
                                         <xs:appinfo>
                                             <xrx:i18n>
@@ -547,9 +554,9 @@
                             </xs:annotation>
                             <xs:complexType>
                                 <xs:choice maxOccurs="unbounded">
-                                        <xs:element ref="h1"/>
-                                        <xs:element ref="text"/>
-                                    </xs:choice>
+                                    <xs:element ref="h1"/>
+                                    <xs:element ref="text"/>
+                                </xs:choice>
                                 <xs:attributeGroup ref="standard"/>
                             </xs:complexType>
                         </xs:element>
@@ -564,66 +571,67 @@
                         </xs:annotation>
                         <xs:complexType>
                             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xs:element ref="persName">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                                <xrxe:content-control>annotation</xrxe:content-control>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="orgName">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                                <xrxe:content-control>annotation</xrxe:content-control>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="class">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                                <xrxe:content-control>annotation</xrxe:content-control>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="placeName">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                                <xrxe:content-control>annotation</xrxe:content-control>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="index">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="geogName">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                                <xrxe:relevant>false</xrxe:relevant>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="divNotes"/>
-                                </xs:choice>
+                                <xs:element ref="persName">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                            <xrxe:content-control>annotation</xrxe:content-control>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="orgName">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                            <xrxe:content-control>annotation</xrxe:content-control>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="class">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                            <xrxe:content-control>annotation</xrxe:content-control>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="placeName">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                            <xrxe:content-control>annotation</xrxe:content-control>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="index">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="geogName">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                            <xrxe:relevant>false</xrxe:relevant>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="divNotes"/>
+                            </xs:choice>
                         </xs:complexType>
                     </xs:element>
                 </xs:sequence>
             </xs:choice>
-            <xs:attribute name="type" use="required"/> <!--Erweiterung-->
+            <xs:attribute name="type" fixed="charter"/>
+            <!--Erweiterung-->
             <xs:attributeGroup ref="picture"/>
             <xs:attributeGroup ref="certainty"/>
             <xs:attributeGroup ref="standard"/>
@@ -651,7 +659,9 @@
                 Handschriftensignatur in einer Bibliothek. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="layout"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
             <xs:attribute name="old"/>
         </xs:complexType>
@@ -674,351 +684,356 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="class"/>
-                    <xs:element ref="abstract"/>
-                    <xs:element name="issued" minOccurs="1" maxOccurs="1">
+                <xs:element ref="class"/>
+                <xs:element ref="abstract"/>
+                <xs:element name="issued" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_issued</xrx:key>
+                                    <xrx:default>issued</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:mixed>false</xrxe:mixed>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="deu"> Diese Konstruktion kann allgemeine
+                            Elemente für die Beschreibung von Ausstellungsort und -zeit verwenden
+                            und ist deshalb den Konstrukten "issuePlace" und "date" bzw.
+                            "publicationStmt" vorzuziehen. [strict!] </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType mixed="true">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_issued</xrx:key>
-                                        <xrx:default>issued</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
                                 <xrxe:mixed>false</xrxe:mixed>
                             </xs:appinfo>
-                            <xs:documentation xml:lang="deu"> Diese Konstruktion kann allgemeine
-                                Elemente für die Beschreibung von Ausstellungsort und -zeit
-                                verwenden und ist deshalb den Konstrukten "issuePlace" und "date"
-                                bzw. "publicationStmt" vorzuziehen. [strict!] </xs:documentation>
                         </xs:annotation>
-                        <xs:complexType mixed="true">
-                            <xs:annotation>
-                                <xs:appinfo source="EditVDU">
-                                    <xrxe:mixed>false</xrxe:mixed>
-                                </xs:appinfo>
-                            </xs:annotation>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xs:element ref="placeName">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>1</xrxe:min-occur>
-                                                <xrxe:max-occur>1</xrxe:max-occur>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:choice>
-                                        <xs:element ref="date">
-                                            <xs:annotation>
-                                                <xs:appinfo source="EditVDU">
-                                                  <xrxe:min-occur>0</xrxe:min-occur>
-                                                  <xrxe:max-occur>1</xrxe:max-occur>
-                                                </xs:appinfo>
-                                                <xs:documentation>
-                                                  <xrx:description>
-                                                  <xrx:i18n>
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:element ref="placeName">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:min-occur>1</xrxe:min-occur>
+                                        <xrxe:max-occur>1</xrxe:max-occur>
+                                    </xs:appinfo>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:choice>
+                                <xs:element ref="date">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>1</xrxe:max-occur>
+                                        </xs:appinfo>
+                                        <xs:documentation>
+                                            <xrx:description>
+                                                <xrx:i18n>
                                                   <xrx:key>cei_issued_date_description</xrx:key>
                                                   <xrx:default>Datum, an dem die Urkunde ausgestellt
                                                   ist. Die Daten werden im Format 'Jahr Monat (als
                                                   Wort) Tag' angegeben.</xrx:default>
-                                                  </xrx:i18n>
-                                                  </xrx:description>
-                                                  <xrx:example>
-                                                  <xrx:i18n>
+                                                </xrx:i18n>
+                                            </xrx:description>
+                                            <xrx:example>
+                                                <xrx:i18n>
                                                   <xrx:key>cei_issued_date_example</xrx:key>
                                                   <xrx:default>&lt;cei:date value="16091001"&gt;1609
                                                   Oktober 1&lt;/cei:date&gt;</xrx:default>
-                                                  </xrx:i18n>
-                                                  </xrx:example>
-                                                </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:element>
-                                        <xs:element ref="dateRange">
-                                            <xs:annotation>
-                                                <xs:appinfo source="EditVDU">
-                                                  <xrxe:min-occur>0</xrxe:min-occur>
-                                                  <xrxe:max-occur>1</xrxe:max-occur>
-                                                </xs:appinfo>
-                                            </xs:annotation>
-                                        </xs:element>
-                                    </xs:choice>
-                                </xs:choice>
-                            <xs:attributeGroup ref="standard"/>
-                            <xs:assert test="(matches(string(date/@value), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and date) or not(date)" xpathDefaultNamespace="##targetNamespace" xerces:message="i18n:wrong-date-format-message">
-                                <xs:annotation>
-                                    <xs:appinfo>
-                                        <xrx:i18n>
-                                            <xrx:key>wrong-date-format-message</xrx:key>
-                                            <xrx:default>Wrong date format. YYYYMMDD is
-                                                expected.</xrx:default>
-                                        </xrx:i18n>
-                                    </xs:appinfo>
-                                </xs:annotation>
-                            </xs:assert>
-                            <xs:assert test="(matches(string(dateRange/@from), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and dateRange) or not(dateRange)" xpathDefaultNamespace="##targetNamespace" xerces:message="i18n:wrong-date-format-message">
-                                <xs:annotation>
-                                    <xs:appinfo>
-                                        <xrx:i18n>
-                                            <xrx:key>wrong-date-format-message</xrx:key>
-                                            <xrx:default>Wrong date format. YYYYMMDD is
-                                                expected.</xrx:default>
-                                        </xrx:i18n>
-                                    </xs:appinfo>
-                                </xs:annotation>
-                            </xs:assert>
-                            <xs:assert test="(matches(string(dateRange/@to), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and dateRange) or not(dateRange)" xpathDefaultNamespace="##targetNamespace" xerces:message="i18n:wrong-date-format-message">
-                                <xs:annotation>
-                                    <xs:appinfo>
-                                        <xrx:i18n>
-                                            <xrx:key>wrong-date-format-message</xrx:key>
-                                            <xrx:default>Wrong date format. YYYYMMDD is
-                                                expected.</xrx:default>
-                                        </xrx:i18n>
-                                    </xs:appinfo>
-                                </xs:annotation>
-                            </xs:assert>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="witnessOrig">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Der einzelne Textzeuge
-                                (MOM)</xs:documentation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
+                                                </xrx:i18n>
+                                            </xrx:example>
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="dateRange">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>1</xrxe:max-occur>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                            </xs:choice>
+                        </xs:choice>
+                        <xs:attributeGroup ref="standard"/>
+                        <xs:assert
+                            test="(matches(string(date/@value), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and date) or not(date)"
+                            xpathDefaultNamespace="##targetNamespace"
+                            xerces:message="i18n:wrong-date-format-message">
+                            <xs:annotation>
+                                <xs:appinfo>
                                     <xrx:i18n>
-                                        <xrx:key>cei_witnessOrig</xrx:key>
-                                        <xrx:default>witnessOrig</xrx:default>
+                                        <xrx:key>wrong-date-format-message</xrx:key>
+                                        <xrx:default>Wrong date format. YYYYMMDD is
+                                            expected.</xrx:default>
                                     </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:mixed>false</xrxe:mixed>
-                            </xs:appinfo>
-                        </xs:annotation>
-                        <xs:complexType mixed="true">
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xs:element ref="traditioForm">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:choice>
-                                        <xs:element ref="archIdentifier"/>
-                                        <xs:element ref="msIdentifier"/>
+                                </xs:appinfo>
+                            </xs:annotation>
+                        </xs:assert>
+                        <xs:assert
+                            test="(matches(string(dateRange/@from), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and dateRange) or not(dateRange)"
+                            xpathDefaultNamespace="##targetNamespace"
+                            xerces:message="i18n:wrong-date-format-message">
+                            <xs:annotation>
+                                <xs:appinfo>
+                                    <xrx:i18n>
+                                        <xrx:key>wrong-date-format-message</xrx:key>
+                                        <xrx:default>Wrong date format. YYYYMMDD is
+                                            expected.</xrx:default>
+                                    </xrx:i18n>
+                                </xs:appinfo>
+                            </xs:annotation>
+                        </xs:assert>
+                        <xs:assert
+                            test="(matches(string(dateRange/@to), '-?[129]?[0-9][0-9][0-9][019][0-9][01239][0-9]') and dateRange) or not(dateRange)"
+                            xpathDefaultNamespace="##targetNamespace"
+                            xerces:message="i18n:wrong-date-format-message">
+                            <xs:annotation>
+                                <xs:appinfo>
+                                    <xrx:i18n>
+                                        <xrx:key>wrong-date-format-message</xrx:key>
+                                        <xrx:default>Wrong date format. YYYYMMDD is
+                                            expected.</xrx:default>
+                                    </xrx:i18n>
+                                </xs:appinfo>
+                            </xs:annotation>
+                        </xs:assert>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="witnessOrig">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Der einzelne Textzeuge
+                            (MOM)</xs:documentation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_witnessOrig</xrx:key>
+                                    <xrx:default>witnessOrig</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:mixed>false</xrxe:mixed>
+                        </xs:appinfo>
+                    </xs:annotation>
+                    <xs:complexType mixed="true">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:element ref="traditioForm">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:min-occur>0</xrxe:min-occur>
+                                    </xs:appinfo>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:choice>
+                                <xs:element ref="archIdentifier"/>
+                                <xs:element ref="msIdentifier"/>
+                            </xs:choice>
+                            <xs:element ref="auth"/>
+                            <xs:element ref="physicalDesc"/>
+                            <xs:element ref="nota"/>
+                            <xs:element ref="rubrum"/>
+                            <xs:element ref="figure">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:relevant>false</xrxe:relevant>
+                                    </xs:appinfo>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element ref="p"/>
+                            <!--Erweiterung-->
+                        </xs:choice>
+                        <xs:attributeGroup ref="certainty"/>
+                        <xs:attribute name="type" type="xs:anySimpleType" use="optional"/>
+                        <xs:attribute name="sigil" type="xs:anySimpleType">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="deu"> P5 sieht dafür das Attribut id
+                                    vor. Diese Lösung ist sowohl dem Element, als auch dem Attribut
+                                    vorzuziehen. [strict!] </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="sameAs" type="xs:anySimpleType" use="optional"/>
+                        <xs:attributeGroup ref="standard"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element ref="witListPar"/>
+                <xs:element name="diplomaticAnalysis">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_diplomaticAnalysis</xrx:key>
+                                    <xrx:default>diplomatic analysis</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:mixed>false</xrxe:mixed>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="deu"> Enthält Bemerkungen zur diplomatischen
+                            Kritik der Urkunde, die formale Beobachtungen der inneren wie äußeren
+                            Merkmale ebenso wie inhaltliche Überlegungen enthalten kann. </xs:documentation>
+                        <xs:documentation xml:lang="eng"> contains a diplomatic analysis of the
+                            document, formal critics or critics by the content. </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType mixed="true">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="listBibl">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_listBibl</xrx:key>
+                                                <xrx:default>listBibl</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:mixed>false</xrxe:mixed>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> undifferenzierte
+                                        Bibliographische Auflistung von Titeln, die die Urkunde
+                                        betreffen.. </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                        <xs:choice>
+                                            <xs:element minOccurs="0" ref="ref"/>
+                                            <xs:element ref="bibl"/>
+                                        </xs:choice>
                                     </xs:choice>
-                                    <xs:element ref="auth"/>
-                                    <xs:element ref="physicalDesc"/>
-                                    <xs:element ref="nota"/>
-                                    <xs:element ref="rubrum"/>
-                                    <xs:element ref="figure">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:relevant>false</xrxe:relevant>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="p"/>
+                                    <xs:attribute name="type"/>
                                     <!--Erweiterung-->
-                                </xs:choice>
-                            <xs:attributeGroup ref="certainty"/>
-                            <xs:attribute name="type" type="xs:anySimpleType" use="optional"/>
-                            <xs:attribute name="sigil" type="xs:anySimpleType">
+                                    <xs:attributeGroup ref="standard"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="listBiblEdition">
                                 <xs:annotation>
-                                    <xs:documentation xml:lang="deu"> P5 sieht dafür das Attribut id
-                                        vor. Diese Lösung ist sowohl dem Element, als auch dem
-                                        Attribut vorzuziehen. [strict!] </xs:documentation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_listBiblEdition</xrx:key>
+                                                <xrx:default>listBiblEdition</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:mixed>false</xrxe:mixed>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> Bibliographische Auflistung
+                                        der Editionen = listBibl type="print". </xs:documentation>
                                 </xs:annotation>
-                            </xs:attribute>
-                            <xs:attribute name="sameAs" type="xs:anySimpleType" use="optional"/>
-                            <xs:attributeGroup ref="standard"/>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element ref="witListPar"/>
-                    <xs:element name="diplomaticAnalysis">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_diplomaticAnalysis</xrx:key>
-                                        <xrx:default>diplomatic analysis</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:mixed>false</xrxe:mixed>
-                            </xs:appinfo>
-                            <xs:documentation xml:lang="deu"> Enthält Bemerkungen zur diplomatischen
-                                Kritik der Urkunde, die formale Beobachtungen der inneren wie
-                                äußeren Merkmale ebenso wie inhaltliche Überlegungen enthalten kann. </xs:documentation>
-                            <xs:documentation xml:lang="eng"> contains a diplomatic analysis of the
-                                document, formal critics or critics by the content.
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType mixed="true">
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xs:element name="listBibl">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
-                                                  <xrx:key>cei_listBibl</xrx:key>
-                                                  <xrx:default>listBibl</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                                <xrxe:mixed>false</xrxe:mixed>
-                                            </xs:appinfo>
-                                            <xs:documentation xml:lang="deu"> undifferenzierte
-                                                Bibliographische Auflistung von Titeln, die die
-                                                Urkunde betreffen.. </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType mixed="true">
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:choice>
-                                                  <xs:element minOccurs="0" ref="ref"/>
-                                                  <xs:element ref="bibl"/>
-                                                  </xs:choice>
-                                                </xs:choice>
-                                            <xs:attribute name="type"/>
-                                            <!--Erweiterung-->
-                                            <xs:attributeGroup ref="standard"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="listBiblEdition">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
-                                                  <xrx:key>cei_listBiblEdition</xrx:key>
-                                                  <xrx:default>listBiblEdition</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                                <xrxe:mixed>false</xrxe:mixed>
-                                            </xs:appinfo>
-                                            <xs:documentation xml:lang="deu"> Bibliographische
-                                                Auflistung der Editionen = listBibl type="print".
-                                            </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType mixed="true">
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:choice>
-                                                  <xs:element minOccurs="0" ref="ref"/>
-                                                  <xs:element ref="bibl"/>
-                                                  </xs:choice>
-                                                </xs:choice>
-                                            <xs:attributeGroup ref="standard"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="listBiblRegest">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
-                                                  <xrx:key>cei_listBiblRegest</xrx:key>
-                                                  <xrx:default>listBiblRegest</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                                <xrxe:mixed>false</xrxe:mixed>
-                                            </xs:appinfo>
-                                            <xs:documentation xml:lang="deu"> Bibliographische
-                                                Auflistungen = listBibl type="regesta".
-                                            </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType mixed="true">
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:choice>
-                                                  <xs:element minOccurs="0" ref="ref"/>
-                                                  <xs:element ref="bibl"/>
-                                                  </xs:choice>
-                                                </xs:choice>
-                                            <xs:attributeGroup ref="standard"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="listBiblFaksimile">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
-                                                  <xrx:key>cei_listBiblFaksimile</xrx:key>
-                                                  <xrx:default>listBiblFaksimile</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                                <xrxe:mixed>false</xrxe:mixed>
-                                            </xs:appinfo>
-                                            <xs:documentation xml:lang="deu"> Bibliographische
-                                                Auflistung der Faksimiles = listBibl
-                                                type="facsimilia" </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType mixed="true">
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:choice>
-                                                  <xs:element minOccurs="0" ref="ref"/>
-                                                  <xs:element ref="bibl"/>
-                                                  </xs:choice>
-                                                </xs:choice>
-                                            <xs:attributeGroup ref="standard"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="listBiblErw">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
-                                                  <xrx:key>cei_listBiblErw</xrx:key>
-                                                  <xrx:default>listBiblErw</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                                <xrxe:mixed>false</xrxe:mixed>
-                                            </xs:appinfo>
-                                            <xs:documentation xml:lang="deu"> Bibliographische
-                                                Auflistung der Erwähnungen = listBibl type="studies"
-                                            </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType mixed="true">
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:choice>
-                                                  <xs:element minOccurs="0" ref="ref"/>
-                                                  <xs:element ref="bibl"/>
-                                                  </xs:choice>
-                                                </xs:choice>
-                                            <xs:attributeGroup ref="standard"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element ref="p" maxOccurs="unbounded">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="quoteOriginaldatierung"/>
-                                    <xs:element ref="nota"/>
-                                    <xs:element ref="rubrum"/>
-                                    <xs:element ref="incipit"/>
-                                    <xs:element ref="divNotes"/>
-                                </xs:choice>
-                            <xs:attributeGroup ref="standard"/>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="lang_MOM">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_lang_MOM</xrx:key>
-                                        <xrx:default>lang_MOM</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:min-occur>0</xrxe:min-occur>
-                                <xrxe:type-type>simpleType</xrxe:type-type>
-                                <xrxe:mixed>false</xrxe:mixed>
-                                <xrxe:control-control>input</xrxe:control-control>
-                            </xs:appinfo>
-                            <xs:documentation> MOM-spezifisch: Eigentlich tenor@lang
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType mixed="true">
-                            <xs:attributeGroup ref="standard"/>
-                        </xs:complexType>
-                    </xs:element>
-                </xs:choice>
+                                <xs:complexType mixed="true">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                        <xs:choice>
+                                            <xs:element minOccurs="0" ref="ref"/>
+                                            <xs:element ref="bibl"/>
+                                        </xs:choice>
+                                    </xs:choice>
+                                    <xs:attributeGroup ref="standard"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="listBiblRegest">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_listBiblRegest</xrx:key>
+                                                <xrx:default>listBiblRegest</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:mixed>false</xrxe:mixed>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> Bibliographische Auflistungen
+                                        = listBibl type="regesta". </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                        <xs:choice>
+                                            <xs:element minOccurs="0" ref="ref"/>
+                                            <xs:element ref="bibl"/>
+                                        </xs:choice>
+                                    </xs:choice>
+                                    <xs:attributeGroup ref="standard"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="listBiblFaksimile">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_listBiblFaksimile</xrx:key>
+                                                <xrx:default>listBiblFaksimile</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:mixed>false</xrxe:mixed>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> Bibliographische Auflistung
+                                        der Faksimiles = listBibl type="facsimilia"
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                        <xs:choice>
+                                            <xs:element minOccurs="0" ref="ref"/>
+                                            <xs:element ref="bibl"/>
+                                        </xs:choice>
+                                    </xs:choice>
+                                    <xs:attributeGroup ref="standard"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="listBiblErw">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_listBiblErw</xrx:key>
+                                                <xrx:default>listBiblErw</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:mixed>false</xrxe:mixed>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> Bibliographische Auflistung
+                                        der Erwähnungen = listBibl type="studies"
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                        <xs:choice>
+                                            <xs:element minOccurs="0" ref="ref"/>
+                                            <xs:element ref="bibl"/>
+                                        </xs:choice>
+                                    </xs:choice>
+                                    <xs:attributeGroup ref="standard"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element ref="p" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                    </xs:appinfo>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element ref="quoteOriginaldatierung"/>
+                            <xs:element ref="nota"/>
+                            <xs:element ref="rubrum"/>
+                            <xs:element ref="incipit"/>
+                            <xs:element ref="divNotes"/>
+                        </xs:choice>
+                        <xs:attributeGroup ref="standard"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="lang_MOM">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_lang_MOM</xrx:key>
+                                    <xrx:default>lang_MOM</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:min-occur>0</xrxe:min-occur>
+                            <xrxe:type-type>simpleType</xrxe:type-type>
+                            <xrxe:mixed>false</xrxe:mixed>
+                            <xrxe:control-control>input</xrxe:control-control>
+                        </xs:appinfo>
+                        <xs:documentation> MOM-spezifisch: Eigentlich tenor@lang </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType mixed="true">
+                        <xs:attributeGroup ref="standard"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1059,12 +1074,12 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="class"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:group ref="layout"/>
-                    <xs:element ref="recipient"/>
-                    <xs:element ref="issuer"/>
-                </xs:choice>
+                <xs:element ref="class"/>
+                <xs:group ref="Sachliches"/>
+                <xs:group ref="layout"/>
+                <xs:element ref="recipient"/>
+                <xs:element ref="issuer"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1100,9 +1115,9 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:group ref="layout"/>
-                                <xs:group ref="biblArch"/>
-                            </xs:choice>
+                            <xs:group ref="layout"/>
+                            <xs:group ref="biblArch"/>
+                        </xs:choice>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1120,9 +1135,9 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:element ref="ref"/>
-                                <xs:element ref="bibl"/>
-                            </xs:choice>
+                            <xs:element ref="ref"/>
+                            <xs:element ref="bibl"/>
+                        </xs:choice>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1142,8 +1157,8 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:element ref="desc"/>
-                            </xs:choice>
+                            <xs:element ref="desc"/>
+                        </xs:choice>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1255,8 +1270,8 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="witness"/>
-                </xs:choice>
+                <xs:element ref="witness"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1278,25 +1293,25 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="traditioForm">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:min-occur>0</xrxe:min-occur>
-                            </xs:appinfo>
-                        </xs:annotation>
-                    </xs:element>
-                    <xs:choice>
-                        <xs:element ref="archIdentifier"/>
-                        <xs:element ref="msIdentifier"/>
-                    </xs:choice>
-                    <xs:element ref="auth"/>
-                    <xs:element ref="physicalDesc"/>
-                    <xs:element ref="nota"/>
-                    <xs:element ref="rubrum"/>
-                    <xs:element ref="figure"/>
-                    <xs:group ref="layout"/>
-                    <xs:group ref="textualElements"/>
+                <xs:element ref="traditioForm">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:min-occur>0</xrxe:min-occur>
+                        </xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+                <xs:choice>
+                    <xs:element ref="archIdentifier"/>
+                    <xs:element ref="msIdentifier"/>
                 </xs:choice>
+                <xs:element ref="auth"/>
+                <xs:element ref="physicalDesc"/>
+                <xs:element ref="nota"/>
+                <xs:element ref="rubrum"/>
+                <xs:element ref="figure"/>
+                <xs:group ref="layout"/>
+                <xs:group ref="textualElements"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="id"/>
             <xs:attribute name="n" type="xs:anySimpleType">
@@ -1330,7 +1345,9 @@
                 entnehmen oder in der profileDesc zu dokumentieren. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="layout"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1349,7 +1366,10 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element ref="foreign"/><xs:group ref="layout"/></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="foreign"/>
+                <xs:group ref="layout"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1367,8 +1387,8 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="index"/>
-                </xs:choice>
+                <xs:element ref="index"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1391,11 +1411,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="notariusDesc"/>
-                    <xs:element ref="sealDesc"/>
-                    <xs:element ref="subscriptio"/>
-                    <xs:element ref="chirograph"/>
-                </xs:choice>
+                <xs:element ref="notariusDesc"/>
+                <xs:element ref="sealDesc"/>
+                <xs:element ref="subscriptio"/>
+                <xs:element ref="chirograph"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1418,11 +1438,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="seal"/>
-                    <xs:element ref="legend"/>
-                    <xs:group ref="layout"/>
-                    <xs:element ref="index"/>
-                </xs:choice>
+                <xs:element ref="seal"/>
+                <xs:element ref="legend"/>
+                <xs:group ref="layout"/>
+                <xs:element ref="index"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1450,14 +1470,14 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="layout"/>
-                    <xs:element ref="sigillant"/>
-                    <xs:element ref="legend"/>
-                    <xs:element ref="sealDimensions"/>
-                    <xs:element ref="sealMaterial"/>
-                    <xs:element ref="sealCondition"/>
-                    <xs:element ref="index"/>
-                </xs:choice>
+                <xs:group ref="layout"/>
+                <xs:element ref="sigillant"/>
+                <xs:element ref="legend"/>
+                <xs:element ref="sealDimensions"/>
+                <xs:element ref="sealMaterial"/>
+                <xs:element ref="sealCondition"/>
+                <xs:element ref="index"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1485,8 +1505,8 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attribute name="place"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1514,9 +1534,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="quote"/>
-                    <xs:group ref="Sachauszeichnung"/>
-                </xs:choice>
+                <xs:element ref="quote"/>
+                <xs:group ref="Sachauszeichnung"/>
+            </xs:choice>
             <xs:attributeGroup ref="reg"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1538,27 +1558,26 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="notariusSub">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                            </xs:appinfo>
-                        </xs:annotation>
-                    </xs:element>
-                    <xs:element ref="notariusSign"/>
-                    <xs:element ref="quote"/>
-                    <xs:element ref="persName"/>
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu"> Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:element ref="index"/>
-                    <xs:element ref="num"/>
+                <xs:element ref="notariusSub">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                        </xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element ref="notariusSign"/>
+                <xs:element ref="quote"/>
+                <xs:element ref="persName"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu"> Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:element ref="index"/>
+                <xs:element ref="num"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1611,9 +1630,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attribute name="position" type="xs:anySimpleType" use="optional"/>
             <xs:attributeGroup ref="lang"/>
@@ -1641,9 +1660,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1666,11 +1685,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="material"/>
-                    <xs:element ref="dimensions"/>
-                    <xs:element ref="condition"/>
-                    <xs:element ref="decoDesc"/>
-                </xs:choice>
+                <xs:element ref="material"/>
+                <xs:element ref="dimensions"/>
+                <xs:element ref="condition"/>
+                <xs:element ref="decoDesc"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1691,8 +1710,8 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="p"/>
-                </xs:choice>
+                <xs:element ref="p"/>
+            </xs:choice>
             <xs:attributeGroup ref="reference"/>
         </xs:complexType>
     </xs:element>
@@ -1712,60 +1731,64 @@
                 Elementen) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element name="width" type="xs:string">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_width</xrx:key>
-                                        <xrx:default>width</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:menu-item>
-                                    <xrx:i18n>
-                                        <xrx:key>textual-tradition</xrx:key>
-                                        <xrx:default>textual tradition</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:menu-item>
-                            </xs:appinfo>
-                        </xs:annotation>
-                    </xs:element><xs:element name="height" type="xs:string">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_height</xrx:key>
-                                        <xrx:default>height</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:menu-item>
-                                    <xrx:i18n>
-                                        <xrx:key>textual-tradition</xrx:key>
-                                        <xrx:default>textual tradition</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:menu-item>
-                            </xs:appinfo>
-                        </xs:annotation>
-                    </xs:element><xs:element name="plica" type="xs:string">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_plica</xrx:key>
-                                        <xrx:default>plica</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:menu-item>
-                                    <xrx:i18n>
-                                        <xrx:key>textual-tradition</xrx:key>
-                                        <xrx:default>textual tradition</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:menu-item>
-                            </xs:appinfo>
-                            <xs:documentation xml:lang="eng"> describes the depth of the fold used
-                                to secure the threads for the seal </xs:documentation>
-                        </xs:annotation>
-                    </xs:element></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="width" type="xs:string">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_width</xrx:key>
+                                    <xrx:default>width</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:menu-item>
+                                <xrx:i18n>
+                                    <xrx:key>textual-tradition</xrx:key>
+                                    <xrx:default>textual tradition</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:menu-item>
+                        </xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="height" type="xs:string">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_height</xrx:key>
+                                    <xrx:default>height</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:menu-item>
+                                <xrx:i18n>
+                                    <xrx:key>textual-tradition</xrx:key>
+                                    <xrx:default>textual tradition</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:menu-item>
+                        </xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="plica" type="xs:string">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_plica</xrx:key>
+                                    <xrx:default>plica</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:menu-item>
+                                <xrx:i18n>
+                                    <xrx:key>textual-tradition</xrx:key>
+                                    <xrx:default>textual tradition</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:menu-item>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="eng"> describes the depth of the fold used to
+                            secure the threads for the seal </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
             <xs:attribute name="type" type="xs:string"/>
             <!--Erweiterung-->
@@ -1816,7 +1839,10 @@
                 written </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element ref="foreign"/><xs:group ref="layout"/></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="foreign"/>
+                <xs:group ref="layout"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1869,9 +1895,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attribute name="position" type="xs:anySimpleType" use="optional"/>
             <xs:attributeGroup ref="lang"/>
@@ -1901,19 +1927,19 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="settlement"/>
-                    <xs:element ref="region"/>
-                    <xs:element ref="country"/>
-                    <xs:element ref="institution"/>
-                    <xs:element ref="repository"/>
-                    <xs:element ref="ref"/>
-                    <xs:element ref="arch"/>
-                    <xs:element ref="archFond"/>
-                    <xs:element ref="idno"/>
-                    <xs:element ref="scope"/>
-                    <xs:element ref="altIdentifier"/>
-                    <xs:element ref="hi"/>
-                </xs:choice>
+                <xs:element ref="settlement"/>
+                <xs:element ref="region"/>
+                <xs:element ref="country"/>
+                <xs:element ref="institution"/>
+                <xs:element ref="repository"/>
+                <xs:element ref="ref"/>
+                <xs:element ref="arch"/>
+                <xs:element ref="archFond"/>
+                <xs:element ref="idno"/>
+                <xs:element ref="scope"/>
+                <xs:element ref="altIdentifier"/>
+                <xs:element ref="hi"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1933,19 +1959,19 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:choice>
-                        <xs:element ref="settlement"/>
-                        <xs:element ref="region"/>
-                        <xs:element ref="country"/>
-                        <xs:element ref="institution"/>
-                        <xs:element ref="repository"/>
-                        <xs:element minOccurs="0" ref="arch"/>
-                    </xs:choice>
-                    <xs:element ref="archFond"/>
-                    <xs:element ref="idno"/>
-                    <xs:element ref="scope"/>
-                    <xs:element ref="note"/>
+                <xs:choice>
+                    <xs:element ref="settlement"/>
+                    <xs:element ref="region"/>
+                    <xs:element ref="country"/>
+                    <xs:element ref="institution"/>
+                    <xs:element ref="repository"/>
+                    <xs:element minOccurs="0" ref="arch"/>
                 </xs:choice>
+                <xs:element ref="archFond"/>
+                <xs:element ref="idno"/>
+                <xs:element ref="scope"/>
+                <xs:element ref="note"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
             <xs:attributeGroup ref="type"/>
         </xs:complexType>
@@ -1971,7 +1997,9 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="layout"/>
+            </xs:choice>
             <xs:attributeGroup ref="expan"/>
             <xs:attributeGroup ref="key"/>
             <xs:attributeGroup ref="lang"/>
@@ -2051,13 +2079,13 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="settlement"/>
-                    <xs:element ref="region"/>
-                    <xs:element ref="country"/>
-                    <xs:element ref="repository"/>
-                    <xs:element ref="idno"/>
-                    <xs:element ref="scope"/>
-                </xs:choice>
+                <xs:element ref="settlement"/>
+                <xs:element ref="region"/>
+                <xs:element ref="country"/>
+                <xs:element ref="repository"/>
+                <xs:element ref="idno"/>
+                <xs:element ref="scope"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2136,10 +2164,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:element ref="num"/>
-                    <xs:element ref="note"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:element ref="num"/>
+                <xs:element ref="note"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2161,11 +2189,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:group ref="Formular"/>
-                    <xs:element ref="pTenor"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:group ref="Formular"/>
+                <xs:element ref="pTenor"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -2190,18 +2218,18 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="archIdentifier"/>
-                    <xs:element ref="msIdentifier"/>
-                    <xs:element ref="bibl"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="a"/>
-                    <xs:element ref="hi"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="sup"/>
-                    <xs:element ref="scope"/>
-                    <!--Erweiterung-->
-                </xs:choice>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="archIdentifier"/>
+                <xs:element ref="msIdentifier"/>
+                <xs:element ref="bibl"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="a"/>
+                <xs:element ref="hi"/>
+                <xs:element ref="c"/>
+                <xs:element ref="sup"/>
+                <xs:element ref="scope"/>
+                <!--Erweiterung-->
+            </xs:choice>
             <xs:attributeGroup ref="resp"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2233,12 +2261,12 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Formular"/>
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="recipient"/>
-                    <xs:element ref="issuer"/>
-                </xs:choice>
+                <xs:group ref="Formular"/>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="recipient"/>
+                <xs:element ref="issuer"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2287,10 +2315,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2319,10 +2347,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2350,10 +2378,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2381,10 +2409,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2413,10 +2441,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2445,12 +2473,12 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="rogatio"/>
-                    <xs:element ref="intercessio"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="rogatio"/>
+                <xs:element ref="intercessio"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2479,10 +2507,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2511,10 +2539,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2543,10 +2571,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2574,10 +2602,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2606,9 +2634,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2637,11 +2665,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element minOccurs="0" maxOccurs="unbounded" ref="setPhrase"/>
-                    <xs:element minOccurs="0" maxOccurs="unbounded" ref="notariusSub"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="setPhrase"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="notariusSub"/>
+            </xs:choice>
             <xs:attributeGroup ref="type">
                 <xs:annotation>
                     <xs:documentation xml:lang="deu"> Die Unterscheidung in "Signumzeile",
@@ -2676,10 +2704,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2700,10 +2728,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2735,9 +2763,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2767,9 +2795,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2896,19 +2924,19 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="hi"/>
-                    <xs:element ref="handShift"/>
-                    <xs:element ref="pict"/>
-                    <xs:element ref="pc"/>
-                    <!--Erweiterung-->
-                    <xs:element ref="w"/>
-                    <!--Erweiterung-->
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="hi"/>
+                <xs:element ref="handShift"/>
+                <xs:element ref="pict"/>
+                <xs:element ref="pc"/>
+                <!--Erweiterung-->
+                <xs:element ref="w"/>
+                <!--Erweiterung-->
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attribute name="extent" type="xs:anySimpleType"/>
             <xs:attribute name="degree" type="xs:anySimpleType">
                 <xs:annotation>
@@ -2963,13 +2991,13 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="handShift"/>
-                    <xs:element ref="pict"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="handShift"/>
+                <xs:element ref="pict"/>
+            </xs:choice>
             <xs:attribute name="extent" type="xs:anySimpleType">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -3085,22 +3113,20 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:group ref="Sachauszeichnung"/>
-                                <xs:group ref="biblArch"/>
-                                <xs:group ref="layout"/>
-                                <xs:group ref="reference"/>
-                                <xs:group ref="textualElements"/>
-                                <xs:element ref="w"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="pc"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="space"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="damage"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="supplied"/>
-                                <!--Erweiterung-->
-                            </xs:choice>
+                            <xs:group ref="Sachauszeichnung"/>
+                            <xs:group ref="biblArch"/>
+                            <xs:group ref="layout"/>
+                            <xs:group ref="reference"/>
+                            <xs:group ref="textualElements"/>
+                            <xs:element ref="w"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="pc"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="space"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="supplied"/>
+                            <!--Erweiterung-->
+                        </xs:choice>
                         <xs:attributeGroup ref="wit"/>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
@@ -3119,18 +3145,18 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:element ref="w"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="add"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="app"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="foreign"/>
-                                <!--Erweiterung-->
-                                <xs:group ref="biblArch"/>
-                                <xs:group ref="layout"/>
-                                <xs:group ref="reference"/>
-                            </xs:choice>
+                            <xs:element ref="w"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="add"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="app"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="foreign"/>
+                            <!--Erweiterung-->
+                            <xs:group ref="biblArch"/>
+                            <xs:group ref="layout"/>
+                            <xs:group ref="reference"/>
+                        </xs:choice>
                         <xs:attribute name="type"/>
                         <!--Erweiterung-->
                         <xs:attributeGroup ref="wit"/>
@@ -3164,14 +3190,14 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="add"/>
-                    <xs:element ref="corr"/>
-                    <xs:element ref="sic"/>
-                    <xs:element ref="damage"/>
-                </xs:choice>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="add"/>
+                <xs:element ref="corr"/>
+                <xs:element ref="sic"/>
+                <xs:element ref="damage"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="abbr">
                 <xs:annotation>
@@ -3206,14 +3232,14 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="add"/>
-                    <xs:element ref="supplied"/>
-                    <xs:element ref="handShift"/>
-                    <xs:group ref="Referenz"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="add"/>
+                <xs:element ref="supplied"/>
+                <xs:element ref="handShift"/>
+                <xs:group ref="Referenz"/>
+            </xs:choice>
             <xs:attribute name="corr">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -3247,16 +3273,16 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="sic"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="damage"/>
-                    <xs:element ref="handShift"/>
-                    <xs:group ref="Sachauszeichnung"/>
-                    <xs:group ref="Referenz"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="sic"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="c"/>
+                <xs:element ref="damage"/>
+                <xs:element ref="handShift"/>
+                <xs:group ref="Sachauszeichnung"/>
+                <xs:group ref="Referenz"/>
+            </xs:choice>
             <xs:attribute name="sic"/>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
@@ -3286,16 +3312,16 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="add"/>
-                    <xs:element ref="supplied"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="damage"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="sic"/>
-                    <xs:group ref="Referenz"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="add"/>
+                <xs:element ref="supplied"/>
+                <xs:element ref="c"/>
+                <xs:element ref="damage"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="sic"/>
+                <xs:group ref="Referenz"/>
+            </xs:choice>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3323,20 +3349,20 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="sic"/>
-                    <xs:element ref="corr"/>
-                    <xs:element ref="del"/>
-                    <xs:element ref="damage"/>
-                    <xs:element ref="handShift"/>
-                    <xs:element ref="w"/>
-                    <!--Erweiterung-->
-                    <xs:group ref="Sachauszeichnung"/>
-                    <xs:group ref="Referenz"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="sic"/>
+                <xs:element ref="corr"/>
+                <xs:element ref="del"/>
+                <xs:element ref="damage"/>
+                <xs:element ref="handShift"/>
+                <xs:element ref="w"/>
+                <!--Erweiterung-->
+                <xs:group ref="Sachauszeichnung"/>
+                <xs:group ref="Referenz"/>
+            </xs:choice>
             <xs:attribute name="status"/>
             <!--Erweiterung-->
             <xs:attributeGroup ref="transcription"/>
@@ -3367,18 +3393,18 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="damage"/>
-                    <xs:element ref="expan"/>
-                    <xs:element ref="w"/>
-                    <!--Erweiterung-->
-                    <xs:element ref="pc"/>
-                    <!--Erweiterung-->
-                    <xs:group ref="Sachauszeichnung"/>
-                    <xs:group ref="Referenz"/>
-                </xs:choice>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="damage"/>
+                <xs:element ref="expan"/>
+                <xs:element ref="w"/>
+                <!--Erweiterung-->
+                <xs:element ref="pc"/>
+                <!--Erweiterung-->
+                <xs:group ref="Sachauszeichnung"/>
+                <xs:group ref="Referenz"/>
+            </xs:choice>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -3611,10 +3637,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:group ref="Formular"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:group ref="Formular"/>
+            </xs:choice>
             <xs:attributeGroup ref="rend"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3754,12 +3780,12 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="bibl"/>
-                    <xs:element ref="archIdentifier"/>
-                    <xs:element ref="msIdentifier"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="bibl"/>
+                <xs:element ref="archIdentifier"/>
+                <xs:element ref="msIdentifier"/>
+            </xs:choice>
             <xs:attribute name="place"/>
             <xs:attributeGroup ref="id"/>
             <xs:attributeGroup ref="type"/>
@@ -3875,8 +3901,8 @@
         </xs:annotation>
         <xs:complexType>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="textualElements"/>
-                </xs:choice>
+                <xs:group ref="textualElements"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3896,8 +3922,8 @@
         </xs:annotation>
         <xs:complexType>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="note"/>
-                </xs:choice>
+                <xs:element ref="note"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -3926,9 +3952,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachauszeichnung"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachauszeichnung"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3994,11 +4020,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachauszeichnung"/>
-                    <xs:group ref="reference"/>
-                    <xs:element ref="foreign"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachauszeichnung"/>
+                <xs:group ref="reference"/>
+                <xs:element ref="foreign"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -4076,9 +4102,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -4118,10 +4144,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="num"/>
-                    <xs:element ref="index"/>
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="num"/>
+                <xs:element ref="index"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -4149,11 +4175,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="w"/>
-                    <!--Erweiterung-->
-                    <xs:element ref="pc"/>
-                    <!--Erweiterung-->
-                </xs:choice>
+                <xs:element ref="w"/>
+                <!--Erweiterung-->
+                <xs:element ref="pc"/>
+                <!--Erweiterung-->
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attribute name="value" type="xs:double"/>
             <xs:attributeGroup ref="lang"/>
@@ -4220,10 +4246,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="ref"/>
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="ref"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attribute name="indexName">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -4290,18 +4316,19 @@
             <xs:documentation xml:lang="deu"> Die Angabe eines spezifischen Tages in einem Kalender
                 (=Datumsangabe). </xs:documentation>
         </xs:annotation>
-        <xs:alternative test="ancestor::issued" type="dateNormalized" xpathDefaultNamespace="##targetNamespace"/>
+        <xs:alternative test="ancestor::issued" type="dateNormalized"
+            xpathDefaultNamespace="##targetNamespace"/>
         <xs:alternative type="date" xpathDefaultNamespace="##targetNamespace"/>
     </xs:element>
     <xs:complexType name="dateGeneral" mixed="true">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element ref="foreign"/>
-                <xs:element ref="num"/>
-                <xs:group ref="Originalbefund"/>
-                <xs:element ref="ref"/>
-                <xs:element ref="figure"/>
-                <!--Erweiterung-->
-            </xs:choice>
+            <xs:element ref="foreign"/>
+            <xs:element ref="num"/>
+            <xs:group ref="Originalbefund"/>
+            <xs:element ref="ref"/>
+            <xs:element ref="figure"/>
+            <!--Erweiterung-->
+        </xs:choice>
         <xs:attributeGroup ref="lang"/>
         <xs:attributeGroup ref="standard"/>
     </xs:complexType>
@@ -4342,10 +4369,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="num"/>
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="num"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attribute name="from" type="normalizedDateValue" use="required">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -4428,19 +4455,18 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="persName"/>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="persName"/>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="identification"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
@@ -4468,23 +4494,22 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="persName"/>
-                        <xs:element ref="orgName"/>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                        <xs:element ref="forename"/>
-                        <xs:element ref="surname"/>
-                        <xs:element ref="rolename"/>
-                    </xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="persName"/>
+                    <xs:element ref="orgName"/>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
+                    <xs:element ref="forename"/>
+                    <xs:element ref="surname"/>
+                    <xs:element ref="rolename"/>
                 </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="identification"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
@@ -4512,10 +4537,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4543,21 +4568,20 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="rolename"/>
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:element ref="orgName"/>
-                    <!--Erweiterung-->
-                    <xs:group ref="Originalbefund"/>
+                <xs:element ref="rolename"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:element ref="orgName"/>
+                <!--Erweiterung-->
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4585,12 +4609,12 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachauszeichnung"/>
-                    <!--Erweiterung-->
-                </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachauszeichnung"/>
+                <!--Erweiterung-->
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4621,19 +4645,18 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="persName"/>
-                    <xs:element ref="orgName"/>
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:group ref="Originalbefund"/>
+                <xs:element ref="foreign"/>
+                <xs:element ref="persName"/>
+                <xs:element ref="orgName"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4663,20 +4686,19 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="persName"/>
-                    <xs:element ref="orgName"/>
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
+                <xs:element ref="persName"/>
+                <xs:element ref="orgName"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4703,18 +4725,17 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:group ref="Originalbefund"/>
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:element ref="persName"/>
+                <xs:element ref="foreign"/>
+                <xs:group ref="Originalbefund"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:element ref="persName"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4826,15 +4847,15 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="index"/>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:element ref="placeName"/>
-                    <!--Erweiterung-->
-                    <xs:element ref="persName"/>
-                    <!--Erweiterung-->
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="index"/>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:element ref="placeName"/>
+                <!--Erweiterung-->
+                <xs:element ref="persName"/>
+                <!--Erweiterung-->
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="key"/>
             <xs:attributeGroup ref="geog"/>
             <xs:attributeGroup ref="type"/>
@@ -4866,10 +4887,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="geog"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
@@ -4931,18 +4952,18 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:element ref="scope"/>
-                                <xs:element name="pubPlace">
-                                    <xs:complexType>
-                                        <xs:simpleContent>
-                                            <xs:extension base="xs:string">
-                                                <xs:attributeGroup ref="standard"/>
-                                            </xs:extension>
-                                        </xs:simpleContent>
-                                    </xs:complexType>
-                                </xs:element>
-                                <xs:group ref="date"/>
-                            </xs:choice>
+                            <xs:element ref="scope"/>
+                            <xs:element name="pubPlace">
+                                <xs:complexType>
+                                    <xs:simpleContent>
+                                        <xs:extension base="xs:string">
+                                            <xs:attributeGroup ref="standard"/>
+                                        </xs:extension>
+                                    </xs:simpleContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:group ref="date"/>
+                        </xs:choice>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -5013,12 +5034,14 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="layout"/>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="quote"/>
-                    <xs:group ref="Referenz"/>
-                    <xs:group ref="BibliographicInformation"/>
-                </xs:choice>
+                <xs:group ref="layout"/>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <!--Erweiterung-->
+                <xs:element ref="quote"/>
+                <xs:group ref="Referenz"/>
+                <xs:group ref="BibliographicInformation"/>
+            </xs:choice>
             <xs:attribute name="status"/>
             <!--Erweiterung-->
             <xs:attribute name="type"/>
@@ -5164,7 +5187,9 @@
                             <xrx:default>certainty</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"
+                    />
                 </xs:appinfo>
                 <xs:documentation xml:lang="deu"> Für Genauigkeitsangaben z.B. bei Datierungen,
                     werden mit Schlüsselwörtern (zu benennen in der encodingDesc) oder kurzen
@@ -5200,7 +5225,9 @@
                             <xrx:default>reg</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"
+                    />
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
@@ -5231,7 +5258,9 @@
                             <xrx:default>type</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"
+                    />
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -7,7 +7,8 @@
             <xs:documentation xml:lang="deu"> Wurzelelement für alle Dokumente, die den Regeln der
                 CEI (Charters Encoding Initiative, http://www.cei.lmu.de) folgen. CEI-Ableger mit
                 Angaben zur EditMOM-Verarbeitung als appinfo und verringert auf ein
-                Auszeichnungskonzept für Monasterium.net 2006-05-21 Änderungen: 2016-05-28: (lem|rdg)@wit eingeführt 2015-10-17: supplied hinzugefügt (GV) 2010-02-08:
+                Auszeichnungskonzept für Monasterium.net 2006-05-21 Änderungen: 2016-05-28:
+                (lem|rdg)@wit eingeführt 2015-10-17: supplied hinzugefügt (GV) 2010-02-08:
                 group:layout als Kind von abstract eingeführt 2009-11-20: listBibl wieder eingeführt
                 2009-09-04: minOccurs="1" und maxOccurs="1" für Elemente "body/idno", "issued" und
                 "date_sort" für Validierung beim Import eingeführt (JG) 2009-09-03: persName als
@@ -38,23 +39,22 @@
                 (GV) 2006-05-18: sourceDescVolltext ergänzt und kleinere editMOM-Ergänzungen (GV)
                 2006-05-17: sourceDesc aufgeräumt; Versuch alle Elemente, die in die Maske kommen,
                 global zu definieren; note aus den Fließtexten geworfen. (GV) 2006-05-16: expan
-                statt abbr für Abkürzung, note/index als eigener Reiter, &lt;caption
-                xml:lang="deu"> eingefügt; Attribute (z.B. id/n) mit
-                &lt;present>no&lt;/present> versehen. Menü "Siegelbeschreibung" ergänzt.
-                &lt;sup> in p und abstract zugelassen, aber nicht in Menüs übernommen, denn diese
-                Tags müssen noch nachbearbeitet werden. (GV) 2006-05-11 Einige Elemente, die in
-                Fließtextfeldern auftauchen, global definiert (pTenor, a, legend), in einigen Fällen
-                &lt;present>no&lt;/present> eingefügt (group etc.) (GV) 2006-05-09 Knoten, die
-                selber nicht angezeigt werden und keine anzuzeigenden Subknoten haben, sind mit dem
-                Attribut &lt;present>no&lt;/present> in der EditMOM-appinfo versehen. Alle
-                Elemente, die als Fließtext auftauchen können, sind global definiert. (GV)
-                2006-05-02 listBibl (listBiblEdition, listBiblRegest, listBiblFaksimile,
-                listBiblErw), sourceDesc (sourceDescRegest), p (p, pTenor) typisiert, um in der
-                Anzeige differenzieren zu können. EditMOM:Auswahlliste eingeführt. (GV) 2006-04-25
-                Weitere &lt;tab>-hinzugefügt. (GV) 2006-04-06 Innerhalb von hi Formular
-                zugelassen; issuer verzweigt wie persName, persName kann auch note enthalten.
-                Weitere Attributlisten plausibler aufgereiht. (GV) 2006-04-05 Reihenfolge der
-                Tenorelemente plausibler angeordnet, hi::target in hi::type korrigiert, ein paar
+                statt abbr für Abkürzung, note/index als eigener Reiter, &lt;caption xml:lang="deu">
+                eingefügt; Attribute (z.B. id/n) mit &lt;present>no&lt;/present> versehen. Menü
+                "Siegelbeschreibung" ergänzt. &lt;sup> in p und abstract zugelassen, aber nicht in
+                Menüs übernommen, denn diese Tags müssen noch nachbearbeitet werden. (GV) 2006-05-11
+                Einige Elemente, die in Fließtextfeldern auftauchen, global definiert (pTenor, a,
+                legend), in einigen Fällen &lt;present>no&lt;/present> eingefügt (group etc.) (GV)
+                2006-05-09 Knoten, die selber nicht angezeigt werden und keine anzuzeigenden
+                Subknoten haben, sind mit dem Attribut &lt;present>no&lt;/present> in der
+                EditMOM-appinfo versehen. Alle Elemente, die als Fließtext auftauchen können, sind
+                global definiert. (GV) 2006-05-02 listBibl (listBiblEdition, listBiblRegest,
+                listBiblFaksimile, listBiblErw), sourceDesc (sourceDescRegest), p (p, pTenor)
+                typisiert, um in der Anzeige differenzieren zu können. EditMOM:Auswahlliste
+                eingeführt. (GV) 2006-04-25 Weitere &lt;tab>-hinzugefügt. (GV) 2006-04-06 Innerhalb
+                von hi Formular zugelassen; issuer verzweigt wie persName, persName kann auch note
+                enthalten. Weitere Attributlisten plausibler aufgereiht. (GV) 2006-04-05 Reihenfolge
+                der Tenorelemente plausibler angeordnet, hi::target in hi::type korrigiert, ein paar
                 Attributlisten plausibler aufgereiht. (GV) 2006-03-28 p aus dem Originalbefund
                 direkt unterhalb von tenor verschoben, um sachlich fehlerhafte Rekursionen zu
                 vermeiden (GV) 2006-03-19 (Ausgangsversion) </xs:documentation>
@@ -90,12 +90,12 @@
                                         <xs:element name="titleStmt">
                                             <xs:annotation>
                                                 <xs:appinfo source="EditVDU">
-                                                    <xrxe:label>
-                                                        <xrx:i18n>
-                                                            <xrx:key>cei_titleStmt</xrx:key>
-                                                            <xrx:default>titleStmt</xrx:default>
-                                                        </xrx:i18n>
-                                                    </xrxe:label>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_titleStmt</xrx:key>
+                                                  <xrx:default>titleStmt</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
                                                 </xs:appinfo>
                                                 <xs:documentation xml:lang="deu"> Den Regeln der TEI
                                                   entsprechend müßten hier verschiedene Elemente
@@ -109,14 +109,14 @@
                                                   <xs:element name="author">
                                                   <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
-                                                                    <xrxe:label>
-                                                                        <xrx:i18n>
-                                                                            <xrx:key>cei_author</xrx:key>
-                                                                            <xrx:default>author</xrx:default>
-                                                                        </xrx:i18n>
-                                                                    </xrxe:label>
-                                                                    <xrxe:relevant>false</xrxe:relevant>
-                                                                </xs:appinfo>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_author</xrx:key>
+                                                  <xrx:default>author</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
+                                                  <xrxe:relevant>false</xrxe:relevant>
+                                                  </xs:appinfo>
                                                   </xs:annotation>
                                                   </xs:element>
                                                   <xs:element ref="p"/>
@@ -129,13 +129,13 @@
                                         <xs:element minOccurs="0" name="sourceDesc">
                                             <xs:annotation>
                                                 <xs:appinfo source="EditVDU">
-                                                    <xrxe:label>
-                                                        <xrx:i18n>
-                                                            <xrx:key>cei_sourceDesc</xrx:key>
-                                                            <xrx:default>sourceDesc</xrx:default>
-                                                        </xrx:i18n>
-                                                    </xrxe:label>
-                                                    <xrxe:relevant>false</xrxe:relevant>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_sourceDesc</xrx:key>
+                                                  <xrx:default>sourceDesc</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
+                                                  <xrxe:relevant>false</xrxe:relevant>
                                                 </xs:appinfo>
                                                 <xs:documentation xml:lang="deu"> enthält die
                                                   bibliographischen Angaben der Quellen, aus denen
@@ -388,10 +388,10 @@
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_sourceDesc</xrx:key>
-                                                        <xrx:default>sourceDesc</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_sourceDesc</xrx:key>
+                                                  <xrx:default>sourceDesc</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                             </xs:appinfo>
                                         </xs:annotation>
@@ -401,13 +401,13 @@
                                                   <xs:element name="sourceDescRegest">
                                                   <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
-                                                                <xrxe:label>
-                                                                    <xrx:i18n>
-                                                                        <xrx:key>cei_sourceDescRegest</xrx:key>
-                                                                        <xrx:default>sourceDescRegest</xrx:default>
-                                                                    </xrx:i18n>
-                                                                </xrxe:label>
-                                                            </xs:appinfo>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_sourceDescRegest</xrx:key>
+                                                  <xrx:default>sourceDescRegest</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
+                                                  </xs:appinfo>
                                                   <xs:documentation xml:lang="deu">
                                                   CEI_MOM-spezifisch: Eigentlich eine SourceDesc,
                                                   die über ein Schlüsselwort "Regest" auf die Quelle
@@ -424,7 +424,9 @@
                                                   </xs:sequence>
                                                   <xs:attribute name="ref">
                                                   <xs:annotation>
-                                                  <xs:documentation xml:lang="deu"> Verweis auf eine Textpassage, zu der hier die Quelle angegeben wird. </xs:documentation>
+                                                  <xs:documentation xml:lang="deu">Verweis auf eine
+                                                  Textpassage, zu der hier die Quelle angegeben
+                                                  wird.</xs:documentation>
                                                   </xs:annotation>
                                                   </xs:attribute>
                                                   <xs:attributeGroup ref="standard"/>
@@ -433,13 +435,13 @@
                                                   <xs:element name="sourceDescVolltext">
                                                   <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
-                                                                <xrxe:label>
-                                                                    <xrx:i18n>
-                                                                        <xrx:key>cei_sourceDescVolltext</xrx:key>
-                                                                        <xrx:default>sourceDescVolltext</xrx:default>
-                                                                    </xrx:i18n>
-                                                                </xrxe:label>
-                                                            </xs:appinfo>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_sourceDescVolltext</xrx:key>
+                                                  <xrx:default>sourceDescVolltext</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
+                                                  </xs:appinfo>
                                                   <xs:documentation xml:lang="deu">
                                                   CEI_MOM-spezifisch: Eigentlich eine SourceDesc,
                                                   die über ein Schlüsselwort "Volltext" auf die
@@ -467,8 +469,8 @@
                                                   <xs:element ref="p">
                                                   <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
-                                                                <xrxe:relevant>false</xrxe:relevant>
-                                                            </xs:appinfo>
+                                                  <xrxe:relevant>false</xrxe:relevant>
+                                                  </xs:appinfo>
                                                   </xs:annotation>
                                                   </xs:element>
                                                 </xs:choice>
@@ -509,13 +511,13 @@
                                         <xs:element minOccurs="1" maxOccurs="1" name="idno">
                                             <xs:annotation>
                                                 <xs:appinfo source="EditVDU">
-                                                    <xrxe:label>
-                                                        <xrx:i18n>
-                                                            <xrx:key>cei_idno</xrx:key>
-                                                            <xrx:default>idno</xrx:default>
-                                                        </xrx:i18n>
-                                                    </xrxe:label>
-                                                    <xrxe:relevant>false</xrxe:relevant>
+                                                  <xrxe:label>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_idno</xrx:key>
+                                                  <xrx:default>idno</xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrxe:label>
+                                                  <xrxe:relevant>false</xrxe:relevant>
                                                 </xs:appinfo>
                                                 <xs:documentation xml:lang="deu"> Gibt die
                                                   Identifikationsnummer der Urkunde im aktuellen
@@ -632,7 +634,7 @@
                     </xs:element>
                 </xs:sequence>
             </xs:choice>
-            <xs:attribute name="type"/>
+            <xs:attribute name="type" use="required"/> <!--Erweiterung-->
             <xs:attributeGroup ref="picture"/>
             <xs:attributeGroup ref="certainty"/>
             <xs:attributeGroup ref="standard"/>
@@ -726,34 +728,33 @@
                                         <xs:element ref="date">
                                             <xs:annotation>
                                                 <xs:appinfo source="EditVDU">
-                                                    <xrxe:min-occur>0</xrxe:min-occur>
-                                                    <xrxe:max-occur>1</xrxe:max-occur>
+                                                  <xrxe:min-occur>0</xrxe:min-occur>
+                                                  <xrxe:max-occur>1</xrxe:max-occur>
                                                 </xs:appinfo>
                                                 <xs:documentation>
-                                                    <xrx:description>
-                                                        <xrx:i18n>
-                                                            <xrx:key>cei_issued_date_description</xrx:key>
-                                                            <xrx:default>Datum, an dem die Urkunde ausgestellt
+                                                  <xrx:description>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_issued_date_description</xrx:key>
+                                                  <xrx:default>Datum, an dem die Urkunde ausgestellt
                                                   ist. Die Daten werden im Format 'Jahr Monat (als
                                                   Wort) Tag' angegeben.</xrx:default>
-                                                        </xrx:i18n>
-                                                    </xrx:description>
-                                                    <xrx:example>
-                                                        <xrx:i18n>
-                                                            <xrx:key>cei_issued_date_example</xrx:key>
-                                                            <xrx:default>&lt;cei:date
-                                                  value="16091001">1609 Oktober
-                                                  1&lt;/cei:date></xrx:default>
-                                                        </xrx:i18n>
-                                                    </xrx:example>
+                                                  </xrx:i18n>
+                                                  </xrx:description>
+                                                  <xrx:example>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_issued_date_example</xrx:key>
+                                                  <xrx:default>&lt;cei:date value="16091001">1609
+                                                  Oktober 1&lt;/cei:date></xrx:default>
+                                                  </xrx:i18n>
+                                                  </xrx:example>
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element ref="dateRange">
                                             <xs:annotation>
                                                 <xs:appinfo source="EditVDU">
-                                                    <xrxe:min-occur>0</xrxe:min-occur>
-                                                    <xrxe:max-occur>1</xrxe:max-occur>
+                                                  <xrxe:min-occur>0</xrxe:min-occur>
+                                                  <xrxe:max-occur>1</xrxe:max-occur>
                                                 </xs:appinfo>
                                             </xs:annotation>
                                         </xs:element>
@@ -802,6 +803,8 @@
                                             </xs:appinfo>
                                         </xs:annotation>
                                     </xs:element>
+                                    <xs:element ref="p"/>
+                                    <!--Erweiterung-->
                                 </xs:choice>
                             </xs:sequence>
                             <xs:attributeGroup ref="certainty"/>
@@ -843,10 +846,10 @@
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_listBibl</xrx:key>
-                                                        <xrx:default>listBibl</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_listBibl</xrx:key>
+                                                  <xrx:default>listBibl</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                                 <xrxe:mixed>false</xrxe:mixed>
                                             </xs:appinfo>
@@ -863,6 +866,8 @@
                                                   </xs:choice>
                                                 </xs:choice>
                                             </xs:sequence>
+                                            <xs:attribute name="type"/>
+                                            <!--Erweiterung-->
                                             <xs:attributeGroup ref="standard"/>
                                         </xs:complexType>
                                     </xs:element>
@@ -870,10 +875,10 @@
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_listBiblEdition</xrx:key>
-                                                        <xrx:default>listBiblEdition</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_listBiblEdition</xrx:key>
+                                                  <xrx:default>listBiblEdition</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                                 <xrxe:mixed>false</xrxe:mixed>
                                             </xs:appinfo>
@@ -897,10 +902,10 @@
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_listBiblRegest</xrx:key>
-                                                        <xrx:default>listBiblRegest</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_listBiblRegest</xrx:key>
+                                                  <xrx:default>listBiblRegest</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                                 <xrxe:mixed>false</xrxe:mixed>
                                             </xs:appinfo>
@@ -924,10 +929,10 @@
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_listBiblFaksimile</xrx:key>
-                                                        <xrx:default>listBiblFaksimile</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_listBiblFaksimile</xrx:key>
+                                                  <xrx:default>listBiblFaksimile</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                                 <xrxe:mixed>false</xrxe:mixed>
                                             </xs:appinfo>
@@ -951,10 +956,10 @@
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
                                                 <xrxe:label>
-                                                    <xrx:i18n>
-                                                        <xrx:key>cei_listBiblErw</xrx:key>
-                                                        <xrx:default>listBiblErw</xrx:default>
-                                                    </xrx:i18n>
+                                                  <xrx:i18n>
+                                                  <xrx:key>cei_listBiblErw</xrx:key>
+                                                  <xrx:default>listBiblErw</xrx:default>
+                                                  </xrx:i18n>
                                                 </xrxe:label>
                                                 <xrxe:mixed>false</xrxe:mixed>
                                             </xs:appinfo>
@@ -1193,7 +1198,8 @@
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation xml:lang="en">add complex text to a tagged part of the document.</xs:documentation>
+            <xs:documentation xml:lang="en">add complex text to a tagged part of the
+                document.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:attributeGroup ref="lang"/>
@@ -1201,6 +1207,46 @@
             <xs:attributeGroup ref="resp"/>
         </xs:complexType>
     </xs:element>
+    <!--Erweiterung-Anfang-->
+    <xs:element name="w">
+        <xs:annotation>
+            <xs:documentation xml:lang="deu">Wort-Element für Transkription.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType mixed="true">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="expan"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="hi"/>
+                <xs:element ref="sic"/>
+                <xs:element ref="seg"/>
+                <xs:element ref="space"/>
+            </xs:choice>
+            <xs:attribute name="id"/>
+            <xs:attribute name="note"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="pc">
+        <xs:annotation>
+            <xs:documentation xml:lang="deu">Satzzeichen-Element für
+                Tranksription.</xs:documentation>
+        </xs:annotation>
+        <xs:complexType mixed="true">
+            <xs:attribute name="id"/>
+        </xs:complexType>
+    </xs:element>
+    <xs:element name="seg">
+        <xs:complexType mixed="true">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="expan"/>
+                <xs:element ref="hi"/>
+                <xs:element ref="damage"/>
+            </xs:choice>
+            <xs:attribute name="type"/>
+            <xs:attribute name="id"/>
+            <xs:attribute name="part"/>
+        </xs:complexType>
+    </xs:element>
+    <!--Erweiterung-Ende-->
     <xs:element name="witListPar">
         <xs:annotation>
             <xs:appinfo source="EditVDU">
@@ -1567,7 +1613,9 @@
                 <xrxe:relevant>true</xrxe:relevant>
             </xs:appinfo>
             <xs:documentation xml:lang="de">Teilurkundenschnitt</xs:documentation>
-            <xs:documentation xml:lang="en">contains a description of the method how a chirograph/carta partita (cfr. VID 44, http://www.cei.lmu.de/VID/#VID_44) is executed, e.g. the text written in the place of cutting, and/or the form of the cutting.</xs:documentation>
+            <xs:documentation xml:lang="en">contains a description of the method how a chirograph
+                (cfr. VID 44, http://www.cei.lmu.de/VID/#VID_44) is executed, e.g. the text written
+                in the place of cutting, and/or the form of the cutting.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence minOccurs="0" maxOccurs="unbounded">
@@ -1591,10 +1639,10 @@
                 <xrxe:content-control>annotation</xrxe:content-control>
                 <xrxe:relevant>false</xrxe:relevant>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu"> Enthält Vermerke des verwahrenden Archivs oder des Empfängers auf der
-                Urkunde.</xs:documentation>
-            <xs:documentation xml:lang="eng">contains notes on the document applied by the preserving archives or the recipient.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Enthält Vermerke des verwahrenden Archivs oder des
+                Empfängers auf der Urkunde.</xs:documentation>
+            <xs:documentation xml:lang="eng">contains notes on the document applied by the
+                preserving archives or the recipient. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -1623,8 +1671,10 @@
                 <xrxe:content-control>annotation</xrxe:content-control>
                 <xrxe:relevant>false</xrxe:relevant>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Enthält die ersten Wörter des Textes. Im Attribute "type" wird angegeben, auf welchen Textteil es sich bezieht,</xs:documentation>
-            <xs:documentation xml:lang="eng">contains the first words of the text. The attribute "type" specifies if it refers to specific part of the text.</xs:documentation>
+            <xs:documentation xml:lang="deu">Enthält die ersten Wörter des Textes. Im Attribute
+                "type" wird angegeben, auf welchen Textteil es sich bezieht,</xs:documentation>
+            <xs:documentation xml:lang="eng">contains the first words of the text. The attribute
+                "type" specifies if it refers to specific part of the text.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -1759,14 +1809,17 @@
                                     </xrx:i18n>
                                 </xrxe:menu-item>
                             </xs:appinfo>
-                            <xs:documentation xml:lang="eng">
-                                describes the depth of the fold used to secure the threads for the seal
-                            </xs:documentation>
+                            <xs:documentation xml:lang="eng"> describes the depth of the fold used
+                                to secure the threads for the seal </xs:documentation>
                         </xs:annotation>
                     </xs:element>
                 </xs:choice>
             </xs:sequence>
             <xs:attributeGroup ref="standard"/>
+            <xs:attribute name="type" type="xs:string"/>
+            <!--Erweiterung-->
+            <xs:attribute name="unit" type="xs:string"/>
+            <!--Erweiterung-->
         </xs:complexType>
     </xs:element>
     <xs:element name="sealDimensions">
@@ -1814,8 +1867,8 @@
         <xs:complexType mixed="true">
             <xs:sequence minOccurs="0" maxOccurs="unbounded">
                 <xs:choice>
-                    <xs:group ref="layout"/>
                     <xs:element ref="foreign"/>
+                    <xs:group ref="layout"/>
                 </xs:choice>
             </xs:sequence>
             <xs:attributeGroup ref="lang"/>
@@ -2092,7 +2145,7 @@
                     </xrx:i18n>
                 </xrxe:menu-item>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">Die Einrichtung, deren teil ein Archiv ist.
+            <xs:documentation xml:lang="deu">Die Einrichtung, deren teil ein Archiv
                 ist.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
@@ -2218,11 +2271,17 @@
                     <xs:element ref="hi"/>
                     <xs:element ref="c"/>
                     <xs:element ref="sup"/>
+                    <xs:element ref="scope"/>
+                    <!--Erweiterung-->
                 </xs:choice>
             </xs:sequence>
             <xs:attributeGroup ref="resp"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
+            <xs:attribute name="type"/>
+            <!--Erweiterung-->
+            <xs:attribute name="witness"/>
+            <!--Erweiterung-->
         </xs:complexType>
     </xs:element>
     <xs:element name="pTenor">
@@ -2502,7 +2561,8 @@
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="en">clause expressing the request for formal documentation (cf. VID n. 326 http://www.cei.lmu.de/VID/VID.php?326)</xs:documentation>
+            <xs:documentation xml:lang="en">clause expressing the request for formal documentation
+                (cf. VID n. 326 http://www.cei.lmu.de/VID/VID.php?326)</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -2519,7 +2579,8 @@
     </xs:element>
     <xs:element name="intercessio">
         <xs:annotation>
-            <xs:documentation xml:lang="en">part of the text describing the intervention of a third to support a petition (cf. VID n. 328)</xs:documentation>
+            <xs:documentation xml:lang="en">part of the text describing the intervention of a third
+                to support a petition (cf. VID n. 328)</xs:documentation>
             <xs:appinfo source="EditVDU">
                 <xrxe:label>
                     <xrx:i18n>
@@ -2868,6 +2929,10 @@
                 <xs:element ref="sic"/>
                 <xs:element ref="handShift"/>
                 <xs:element ref="unclear"/>
+                <xs:element ref="w"/>
+                <!--Erweiterung-->
+                <xs:element ref="pc"/>
+                <!--Erweiterung-->
             </xs:choice>
         </xs:sequence>
     </xs:group>
@@ -2946,6 +3011,10 @@
                     <xs:element ref="hi"/>
                     <xs:element ref="handShift"/>
                     <xs:element ref="pict"/>
+                    <xs:element ref="pc"/>
+                    <!--Erweiterung-->
+                    <xs:element ref="w"/>
+                    <!--Erweiterung-->
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
             </xs:sequence>
@@ -2998,7 +3067,8 @@
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu"> enthält Text, der nicht eindeutig lesbar sind. </xs:documentation>
+            <xs:documentation xml:lang="deu"> enthält Text, der nicht eindeutig lesbar sind.
+            </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3132,6 +3202,16 @@
                                 <xs:group ref="layout"/>
                                 <xs:group ref="reference"/>
                                 <xs:group ref="textualElements"/>
+                                <xs:element ref="w"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="pc"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="space"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="damage"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="supplied"/>
+                                <!--Erweiterung-->
                             </xs:choice>
                         </xs:sequence>
                         <xs:attributeGroup ref="wit"/>
@@ -3153,11 +3233,21 @@
                     <xs:complexType mixed="true">
                         <xs:sequence>
                             <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                <xs:element ref="w"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="add"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="app"/>
+                                <!--Erweiterung-->
+                                <xs:element ref="foreign"/>
+                                <!--Erweiterung-->
                                 <xs:group ref="biblArch"/>
                                 <xs:group ref="layout"/>
                                 <xs:group ref="reference"/>
                             </xs:choice>
                         </xs:sequence>
+                        <xs:attribute name="type"/>
+                        <!--Erweiterung-->
                         <xs:attributeGroup ref="wit"/>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
@@ -3367,10 +3457,14 @@
                     <xs:element ref="del"/>
                     <xs:element ref="damage"/>
                     <xs:element ref="handShift"/>
+                    <xs:element ref="w"/>
+                    <!--Erweiterung-->
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
             </xs:sequence>
+            <xs:attribute name="status"/>
+            <!--Erweiterung-->
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -3394,9 +3488,8 @@
                 <xrxe:min-occur>0</xrxe:min-occur>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">
-                Hinzufügungen von Text, der in der Vorlage nicht dokumentiert ist, durch den Editor.
-            </xs:documentation>
+            <xs:documentation xml:lang="deu"> Hinzufügungen von Text, der in der Vorlage nicht
+                dokumentiert ist, durch den Editor. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -3406,6 +3499,10 @@
                     <xs:element ref="pb"/>
                     <xs:element ref="damage"/>
                     <xs:element ref="expan"/>
+                    <xs:element ref="w"/>
+                    <!--Erweiterung-->
+                    <xs:element ref="pc"/>
+                    <!--Erweiterung-->
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
@@ -3413,6 +3510,10 @@
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
+            <xs:attribute name="source"/>
+            <!--Erweiterung-->
+            <xs:attribute name="reason"/>
+            <!--Erweiterung-->
         </xs:complexType>
     </xs:element>
     <xs:element name="pict">
@@ -3552,6 +3653,8 @@
             <xs:documentation xml:lang="eng">Line break in the source. </xs:documentation>
         </xs:annotation>
         <xs:complexType>
+            <xs:attribute name="break"/>
+            <!--Erweiterung-->
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -4189,6 +4292,14 @@
             <xs:documentation xml:lang="deu">Eine Zahlenangabe </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
+            <xs:sequence>
+                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                    <xs:element ref="w"/>
+                    <!--Erweiterung-->
+                    <xs:element ref="pc"/>
+                    <!--Erweiterung-->
+                </xs:choice>
+            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="value"/>
             <xs:attributeGroup ref="lang"/>
@@ -4204,7 +4315,7 @@
                 <xs:element ref="orgName"/>
                 <xs:choice>
                     <xs:annotation>
-                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben</xs:documentation>
                     </xs:annotation>
                     <xs:element ref="placeName"/>
                     <xs:element ref="geogName"/>
@@ -4227,6 +4338,8 @@
         <xs:choice>
             <xs:element ref="date"/>
             <xs:element ref="dateRange"/>
+            <xs:element ref="w"/>
+            <!--Erweiterung-->
         </xs:choice>
     </xs:group>
     <xs:element name="index">
@@ -4331,6 +4444,8 @@
                     <xs:element ref="num"/>
                     <xs:group ref="Originalbefund"/>
                     <xs:element ref="ref"/>
+                    <xs:element ref="figure"/>
+                    <!-- Erweiterung -->
                 </xs:choice>
             </xs:sequence>
             <xs:attributeGroup ref="date"/>
@@ -4565,7 +4680,8 @@
                 </xrxe:menu-item>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">ein Familienname oder anderer Beiname, der zur Unterscheidung einer Person z.B. durch Gruppenzuordnung dient.</xs:documentation>
+            <xs:documentation xml:lang="deu">ein Familienname oder anderer Beiname, der zur
+                Unterscheidung einer Person z.B. durch Gruppenzuordnung dient.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4581,6 +4697,8 @@
                     </xs:choice>
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
+                    <xs:element ref="orgName"/>
+                    <!--Erweiterung-->
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
             </xs:sequence>
@@ -4606,7 +4724,8 @@
                 </xrxe:menu-item>
                 <xrxe:max-occur>unbounded</xrxe:max-occur>
             </xs:appinfo>
-            <xs:documentation xml:lang="deu">ein Rollennamen, z.B. Adelstitel, Anrede, Epitheton ...</xs:documentation>
+            <xs:documentation xml:lang="deu">ein Rollennamen, z.B. Adelstitel, Anrede, Epitheton
+                ...</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:sequence>
@@ -4614,6 +4733,8 @@
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
+                    <xs:group ref="Sachauszeichnung"/>
+                    <!--Erweiterung-->
                 </xs:choice>
             </xs:sequence>
             <xs:attributeGroup ref="lang"/>
@@ -4779,8 +4900,7 @@
                     </xrx:i18n>
                 </xrxe:label>
             </xs:appinfo>
-            <xs:documentation>der Name einer Region, eines Bundeslandes u.ä.
-      </xs:documentation>
+            <xs:documentation>der Name einer Region, eines Bundeslandes u.ä. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:attributeGroup ref="type"/>
@@ -4862,6 +4982,10 @@
                     <xs:element ref="index"/>
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
+                    <xs:element ref="placeName"/>
+                    <!--Erweiterung-->
+                    <xs:element ref="persName"/>
+                    <!--Erweiterung-->
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
             </xs:sequence>
@@ -5055,6 +5179,10 @@
                     <xs:group ref="BibliographicInformation"/>
                 </xs:choice>
             </xs:sequence>
+            <xs:attribute name="status"/>
+            <!--Erweiterung-->
+            <xs:attribute name="type"/>
+            <!--Erweiterung-->
             <xs:attributeGroup ref="key"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -5196,7 +5324,9 @@
                             <xrx:default>certainty</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"
+                    />
                 </xs:appinfo>
                 <xs:documentation xml:lang="deu"> Für Genauigkeitsangaben z.B. bei Datierungen,
                     werden mit Schlüsselwörtern (zu benennen in der encodingDesc) oder kurzen
@@ -5232,7 +5362,9 @@
                             <xrx:default>reg</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"
+                    />
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
@@ -5248,8 +5380,8 @@
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">Der verantwortliche Bearbeiter für die
-                    Kodierung, den Inhalt der Kodierung oder die vergebenen Attribute.</xs:documentation>
+                <xs:documentation xml:lang="deu">Der verantwortliche Bearbeiter für die Kodierung,
+                    den Inhalt der Kodierung oder die vergebenen Attribute.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5263,7 +5395,9 @@
                             <xrx:default>type</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"
+                    />
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
@@ -5440,6 +5574,8 @@
         <xs:attributeGroup ref="n"/>
         <xs:attributeGroup ref="facs"/>
         <xs:attributeGroup ref="resp"/>
+        <xs:attributeGroup ref="rend"/>
+        <!--Erweiterung-->
     </xs:attributeGroup>
     <xs:attributeGroup name="facs">
         <xs:attribute name="facs">
@@ -5468,10 +5604,8 @@
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">
-          Eine im gesamten Dokument eindeutige ID, die mit einem Buchtstaben
-          beginnt.
-              </xs:documentation>
+                <xs:documentation xml:lang="deu"> Eine im gesamten Dokument eindeutige ID, die mit
+                    einem Buchstaben beginnt. </xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5570,7 +5704,8 @@
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="en">Reference to textual witness identified in charter description.</xs:documentation>
+                <xs:documentation xml:lang="en">Reference to textual witness identified in charter
+                    description.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>
@@ -5585,9 +5720,10 @@
                         </xrx:i18n>
                     </xrxe:label>
                 </xs:appinfo>
-                <xs:documentation xml:lang="deu">Bezeichner der 
-                    Ressource (bevorzugt eine URI), auf der Inhalt eines Textes verweist.</xs:documentation>
-                <xs:documentation xml:lang="en">Reference to a resource (preferable URI) wich is referenced by the content of a text.</xs:documentation>
+                <xs:documentation xml:lang="deu">Bezeichner der Ressource (bevorzugt eine URI), auf
+                    der Inhalt eines Textes verweist.</xs:documentation>
+                <xs:documentation xml:lang="en">Reference to a resource (preferable URI) wich is
+                    referenced by the content of a text.</xs:documentation>
             </xs:annotation>
         </xs:attribute>
     </xs:attributeGroup>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -1,4 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?><xs:schema xmlns="http://www.monasterium.net/NS/cei" xmlns:xerces="http://xerces.apache.org" xmlns:xrxe="http://www.monasterium.net/NS/xrxe" xmlns:xrx="http://www.monasterium.net/NS/xrx" xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.monasterium.net/NS/cei" id="cei10">
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://www.monasterium.net/NS/cei" xmlns:xerces="http://xerces.apache.org"
+    xmlns:xrxe="http://www.monasterium.net/NS/xrxe" xmlns:xrx="http://www.monasterium.net/NS/xrx"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified"
+    elementFormDefault="qualified" targetNamespace="http://www.monasterium.net/NS/cei" id="cei10">
     <xs:element name="cei">
         <xs:annotation>
             <xs:documentation xml:lang="deu"> Wurzelelement für alle Dokumente, die den Regeln der
@@ -36,22 +40,23 @@
                 (GV) 2006-05-18: sourceDescVolltext ergänzt und kleinere editMOM-Ergänzungen (GV)
                 2006-05-17: sourceDesc aufgeräumt; Versuch alle Elemente, die in die Maske kommen,
                 global zu definieren; note aus den Fließtexten geworfen. (GV) 2006-05-16: expan
-                statt abbr für Abkürzung, note/index als eigener Reiter, &lt;caption xml:lang="deu"&gt;
-                eingefügt; Attribute (z.B. id/n) mit &lt;present&gt;no&lt;/present&gt; versehen. Menü
-                "Siegelbeschreibung" ergänzt. &lt;sup&gt; in p und abstract zugelassen, aber nicht in
-                Menüs übernommen, denn diese Tags müssen noch nachbearbeitet werden. (GV) 2006-05-11
-                Einige Elemente, die in Fließtextfeldern auftauchen, global definiert (pTenor, a,
-                legend), in einigen Fällen &lt;present&gt;no&lt;/present&gt; eingefügt (group etc.) (GV)
-                2006-05-09 Knoten, die selber nicht angezeigt werden und keine anzuzeigenden
-                Subknoten haben, sind mit dem Attribut &lt;present&gt;no&lt;/present&gt; in der
-                EditMOM-appinfo versehen. Alle Elemente, die als Fließtext auftauchen können, sind
-                global definiert. (GV) 2006-05-02 listBibl (listBiblEdition, listBiblRegest,
-                listBiblFaksimile, listBiblErw), sourceDesc (sourceDescRegest), p (p, pTenor)
-                typisiert, um in der Anzeige differenzieren zu können. EditMOM:Auswahlliste
-                eingeführt. (GV) 2006-04-25 Weitere &lt;tab&gt;-hinzugefügt. (GV) 2006-04-06 Innerhalb
-                von hi Formular zugelassen; issuer verzweigt wie persName, persName kann auch note
-                enthalten. Weitere Attributlisten plausibler aufgereiht. (GV) 2006-04-05 Reihenfolge
-                der Tenorelemente plausibler angeordnet, hi::target in hi::type korrigiert, ein paar
+                statt abbr für Abkürzung, note/index als eigener Reiter, &lt;caption
+                xml:lang="deu"&gt; eingefügt; Attribute (z.B. id/n) mit
+                &lt;present&gt;no&lt;/present&gt; versehen. Menü "Siegelbeschreibung" ergänzt.
+                &lt;sup&gt; in p und abstract zugelassen, aber nicht in Menüs übernommen, denn diese
+                Tags müssen noch nachbearbeitet werden. (GV) 2006-05-11 Einige Elemente, die in
+                Fließtextfeldern auftauchen, global definiert (pTenor, a, legend), in einigen Fällen
+                &lt;present&gt;no&lt;/present&gt; eingefügt (group etc.) (GV) 2006-05-09 Knoten, die
+                selber nicht angezeigt werden und keine anzuzeigenden Subknoten haben, sind mit dem
+                Attribut &lt;present&gt;no&lt;/present&gt; in der EditMOM-appinfo versehen. Alle
+                Elemente, die als Fließtext auftauchen können, sind global definiert. (GV)
+                2006-05-02 listBibl (listBiblEdition, listBiblRegest, listBiblFaksimile,
+                listBiblErw), sourceDesc (sourceDescRegest), p (p, pTenor) typisiert, um in der
+                Anzeige differenzieren zu können. EditMOM:Auswahlliste eingeführt. (GV) 2006-04-25
+                Weitere &lt;tab&gt;-hinzugefügt. (GV) 2006-04-06 Innerhalb von hi Formular
+                zugelassen; issuer verzweigt wie persName, persName kann auch note enthalten.
+                Weitere Attributlisten plausibler aufgereiht. (GV) 2006-04-05 Reihenfolge der
+                Tenorelemente plausibler angeordnet, hi::target in hi::type korrigiert, ein paar
                 Attributlisten plausibler aufgereiht. (GV) 2006-03-28 p aus dem Originalbefund
                 direkt unterhalb von tenor verschoben, um sachlich fehlerhafte Rekursionen zu
                 vermeiden (GV) 2006-03-19 (Ausgangsversion) </xs:documentation>
@@ -116,7 +121,7 @@
                                                   </xs:annotation>
                                                   </xs:element>
                                                   <xs:element ref="p"/>
-                                                  </xs:choice>
+                                                </xs:choice>
                                                 <xs:attributeGroup ref="standard"/>
                                             </xs:complexType>
                                         </xs:element>
@@ -143,7 +148,7 @@
                                             <xs:complexType>
                                                 <xs:choice minOccurs="0">
                                                   <xs:element ref="p"/>
-                                                  </xs:choice>
+                                                </xs:choice>
                                                 <xs:attributeGroup ref="standard"/>
                                             </xs:complexType>
                                         </xs:element>
@@ -168,9 +173,9 @@
                                 </xs:annotation>
                                 <xs:complexType>
                                     <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                            <xs:element ref="p"/>
-                                            <xs:element ref="respStmt"/>
-                                        </xs:choice>
+                                        <xs:element ref="p"/>
+                                        <xs:element ref="respStmt"/>
+                                    </xs:choice>
                                     <xs:attributeGroup ref="standard"/>
                                 </xs:complexType>
                             </xs:element>
@@ -223,73 +228,72 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element name="publisher">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_publisher</xrx:key>
-                                        <xrx:default>publisher</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:relevant>false</xrxe:relevant>
-                            </xs:appinfo>
-                        </xs:annotation>
-                        <xs:complexType>
-                            <xs:simpleContent>
-                                <xs:extension base="xs:anySimpleType">
-                                    <xs:attributeGroup ref="standard"/>
-                                </xs:extension>
-                            </xs:simpleContent>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="pubPlace">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_pubPlace</xrx:key>
-                                        <xrx:default>pubPlace</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:relevant>false</xrxe:relevant>
-                            </xs:appinfo>
-                            <xs:documentation xml:lang="deu">Ort der
-                                Veröffentlichung</xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType>
-                            <xs:simpleContent>
-                                <xs:extension base="xs:anySimpleType">
-                                    <xs:attributeGroup ref="standard"/>
-                                </xs:extension>
-                            </xs:simpleContent>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="availability">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_availability</xrx:key>
-                                        <xrx:default>availability</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:relevant>false</xrxe:relevant>
-                            </xs:appinfo>
-                            <xs:documentation xml:lang="deu"> Verfügbarkeit und insbesondere ihre
-                                Einschränkungen ("restricted") </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType mixed="true">
-                            <xs:sequence>
-                                <xs:element ref="p" minOccurs="0"/>
-                            </xs:sequence>
-                            <xs:attribute name="status" type="xs:anySimpleType"/>
-                            <xs:attributeGroup ref="standard"/>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:group ref="date"/>
-                    <xs:element ref="p"/>
-                </xs:choice>
+                <xs:element name="publisher">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_publisher</xrx:key>
+                                    <xrx:default>publisher</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:relevant>false</xrxe:relevant>
+                        </xs:appinfo>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:simpleContent>
+                            <xs:extension base="xs:anySimpleType">
+                                <xs:attributeGroup ref="standard"/>
+                            </xs:extension>
+                        </xs:simpleContent>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="pubPlace">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_pubPlace</xrx:key>
+                                    <xrx:default>pubPlace</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:relevant>false</xrxe:relevant>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="deu">Ort der Veröffentlichung</xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:simpleContent>
+                            <xs:extension base="xs:anySimpleType">
+                                <xs:attributeGroup ref="standard"/>
+                            </xs:extension>
+                        </xs:simpleContent>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="availability">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_availability</xrx:key>
+                                    <xrx:default>availability</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:relevant>false</xrxe:relevant>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="deu"> Verfügbarkeit und insbesondere ihre
+                            Einschränkungen ("restricted") </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType mixed="true">
+                        <xs:sequence>
+                            <xs:element ref="p" minOccurs="0"/>
+                        </xs:sequence>
+                        <xs:attribute name="status" type="xs:anySimpleType"/>
+                        <xs:attributeGroup ref="standard"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:group ref="date"/>
+                <xs:element ref="p"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -309,35 +313,34 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="name"/>
-                    <xs:element name="resp">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_resp</xrx:key>
-                                        <xrx:default>resp</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:relevant>false</xrxe:relevant>
-                            </xs:appinfo>
-                            <xs:documentation xml:lang="deu"> beschreibt die intellektuelle
-                                Verantwortlichkeit einer Person </xs:documentation>
-                            <xs:documentation xml:lang="eng"> contains a phrase describing the
-                                nature of a person's intellectual responsibility.
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType>
-                            <xs:simpleContent>
-                                <xs:extension base="xs:string">
-                                    <xs:attributeGroup ref="identification"/>
-                                    <xs:attributeGroup ref="standard"/>
-                                </xs:extension>
-                            </xs:simpleContent>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:group ref="date"/>
-                </xs:choice>
+                <xs:element ref="name"/>
+                <xs:element name="resp">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_resp</xrx:key>
+                                    <xrx:default>resp</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:relevant>false</xrxe:relevant>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="deu"> beschreibt die intellektuelle
+                            Verantwortlichkeit einer Person </xs:documentation>
+                        <xs:documentation xml:lang="eng"> contains a phrase describing the nature of
+                            a person's intellectual responsibility. </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:simpleContent>
+                            <xs:extension base="xs:string">
+                                <xs:attributeGroup ref="identification"/>
+                                <xs:attributeGroup ref="standard"/>
+                            </xs:extension>
+                        </xs:simpleContent>
+                    </xs:complexType>
+                </xs:element>
+                <xs:group ref="date"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -370,21 +373,21 @@
                         </xs:annotation>
                         <xs:complexType mixed="true">
                             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xs:element name="sourceDesc">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
+                                <xs:element name="sourceDesc">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:label>
+                                                <xrx:i18n>
                                                   <xrx:key>cei_sourceDesc</xrx:key>
                                                   <xrx:default>sourceDesc</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                        <xs:complexType>
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:element name="sourceDescRegest">
-                                                  <xs:annotation>
+                                                </xrx:i18n>
+                                            </xrxe:label>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                    <xs:complexType>
+                                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:element name="sourceDescRegest">
+                                                <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
                                                   <xrxe:label>
                                                   <xrx:i18n>
@@ -397,8 +400,8 @@
                                                   CEI_MOM-spezifisch: Eigentlich eine SourceDesc,
                                                   die über ein Schlüsselwort "Regest" auf die Quelle
                                                   des Regests verweist. </xs:documentation>
-                                                  </xs:annotation>
-                                                  <xs:complexType>
+                                                </xs:annotation>
+                                                <xs:complexType>
                                                   <xs:sequence>
                                                   <xs:element maxOccurs="unbounded" ref="bibl">
                                                   <xs:annotation>
@@ -415,10 +418,10 @@
                                                   </xs:annotation>
                                                   </xs:attribute>
                                                   <xs:attributeGroup ref="standard"/>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  <xs:element name="sourceDescVolltext">
-                                                  <xs:annotation>
+                                                </xs:complexType>
+                                            </xs:element>
+                                            <xs:element name="sourceDescVolltext">
+                                                <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
                                                   <xrxe:label>
                                                   <xrx:i18n>
@@ -431,8 +434,8 @@
                                                   CEI_MOM-spezifisch: Eigentlich eine SourceDesc,
                                                   die über ein Schlüsselwort "Volltext" auf die
                                                   Quelle des Regests verweist. </xs:documentation>
-                                                  </xs:annotation>
-                                                  <xs:complexType>
+                                                </xs:annotation>
+                                                <xs:complexType>
                                                   <xs:sequence>
                                                   <xs:element maxOccurs="unbounded" ref="bibl">
                                                   <xs:annotation>
@@ -449,35 +452,35 @@
                                                   </xs:annotation>
                                                   </xs:attribute>
                                                   <xs:attributeGroup ref="standard"/>
-                                                  </xs:complexType>
-                                                  </xs:element>
-                                                  <xs:element ref="p">
-                                                  <xs:annotation>
+                                                </xs:complexType>
+                                            </xs:element>
+                                            <xs:element ref="p">
+                                                <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
                                                   <xrxe:relevant>false</xrxe:relevant>
                                                   </xs:appinfo>
-                                                  </xs:annotation>
-                                                  </xs:element>
-                                                </xs:choice>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element ref="publicationStmt">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:relevant>false</xrxe:relevant>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:group ref="textualElements"/>
-                                    <xs:group ref="reference"/>
-                                    <xs:element ref="provenance">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:relevant>false</xrxe:relevant>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                </xs:choice>
+                                                </xs:annotation>
+                                            </xs:element>
+                                        </xs:choice>
+                                    </xs:complexType>
+                                </xs:element>
+                                <xs:element ref="publicationStmt">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:relevant>false</xrxe:relevant>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:group ref="textualElements"/>
+                                <xs:group ref="reference"/>
+                                <xs:element ref="provenance">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:relevant>false</xrxe:relevant>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                            </xs:choice>
                         </xs:complexType>
                     </xs:element>
                     <xs:choice>
@@ -537,9 +540,9 @@
                             </xs:annotation>
                             <xs:complexType>
                                 <xs:choice maxOccurs="unbounded">
-                                        <xs:element ref="h1"/>
-                                        <xs:element ref="text"/>
-                                    </xs:choice>
+                                    <xs:element ref="h1"/>
+                                    <xs:element ref="text"/>
+                                </xs:choice>
                                 <xs:attributeGroup ref="standard"/>
                             </xs:complexType>
                         </xs:element>
@@ -554,66 +557,67 @@
                         </xs:annotation>
                         <xs:complexType>
                             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xs:element ref="persName">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                                <xrxe:content-control>annotation</xrxe:content-control>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="orgName">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                                <xrxe:content-control>annotation</xrxe:content-control>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="class">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                                <xrxe:content-control>annotation</xrxe:content-control>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="placeName">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                                <xrxe:content-control>annotation</xrxe:content-control>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="index">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="geogName">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                                <xrxe:relevant>false</xrxe:relevant>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="divNotes"/>
-                                </xs:choice>
+                                <xs:element ref="persName">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                            <xrxe:content-control>annotation</xrxe:content-control>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="orgName">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                            <xrxe:content-control>annotation</xrxe:content-control>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="class">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                            <xrxe:content-control>annotation</xrxe:content-control>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="placeName">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                            <xrxe:content-control>annotation</xrxe:content-control>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="index">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="geogName">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                            <xrxe:relevant>false</xrxe:relevant>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="divNotes"/>
+                            </xs:choice>
                         </xs:complexType>
                     </xs:element>
                 </xs:sequence>
             </xs:choice>
-            <xs:attribute name="type" use="required"/> <!--Erweiterung-->
+            <xs:attribute name="type" fixed="charter"/>
+            <!--Erweiterung-->
             <xs:attributeGroup ref="picture"/>
             <xs:attributeGroup ref="certainty"/>
             <xs:attributeGroup ref="standard"/>
@@ -641,7 +645,9 @@
                 Handschriftensignatur in einer Bibliothek. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="layout"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
             <xs:attribute name="old"/>
         </xs:complexType>
@@ -664,318 +670,312 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="class"/>
-                    <xs:element ref="abstract"/>
-                    <xs:element name="issued" minOccurs="1" maxOccurs="1">
+                <xs:element ref="class"/>
+                <xs:element ref="abstract"/>
+                <xs:element name="issued" minOccurs="1" maxOccurs="1">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_issued</xrx:key>
+                                    <xrx:default>issued</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:mixed>false</xrxe:mixed>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="deu"> Diese Konstruktion kann allgemeine
+                            Elemente für die Beschreibung von Ausstellungsort und -zeit verwenden
+                            und ist deshalb den Konstrukten "issuePlace" und "date" bzw.
+                            "publicationStmt" vorzuziehen. [strict!] </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType mixed="true">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_issued</xrx:key>
-                                        <xrx:default>issued</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
                                 <xrxe:mixed>false</xrxe:mixed>
                             </xs:appinfo>
-                            <xs:documentation xml:lang="deu"> Diese Konstruktion kann allgemeine
-                                Elemente für die Beschreibung von Ausstellungsort und -zeit
-                                verwenden und ist deshalb den Konstrukten "issuePlace" und "date"
-                                bzw. "publicationStmt" vorzuziehen. [strict!] </xs:documentation>
                         </xs:annotation>
-                        <xs:complexType mixed="true">
-                            <xs:annotation>
-                                <xs:appinfo source="EditVDU">
-                                    <xrxe:mixed>false</xrxe:mixed>
-                                </xs:appinfo>
-                            </xs:annotation>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xs:element ref="placeName">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>1</xrxe:min-occur>
-                                                <xrxe:max-occur>1</xrxe:max-occur>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:choice>
-                                        <xs:element ref="date">
-                                            <xs:annotation>
-                                                <xs:appinfo source="EditVDU">
-                                                  <xrxe:min-occur>0</xrxe:min-occur>
-                                                  <xrxe:max-occur>1</xrxe:max-occur>
-                                                </xs:appinfo>
-                                                <xs:documentation>
-                                                  <xrx:description>
-                                                  <xrx:i18n>
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:element ref="placeName">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:min-occur>1</xrxe:min-occur>
+                                        <xrxe:max-occur>1</xrxe:max-occur>
+                                    </xs:appinfo>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:choice>
+                                <xs:element ref="date">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>1</xrxe:max-occur>
+                                        </xs:appinfo>
+                                        <xs:documentation>
+                                            <xrx:description>
+                                                <xrx:i18n>
                                                   <xrx:key>cei_issued_date_description</xrx:key>
                                                   <xrx:default>Datum, an dem die Urkunde ausgestellt
                                                   ist. Die Daten werden im Format 'Jahr Monat (als
                                                   Wort) Tag' angegeben.</xrx:default>
-                                                  </xrx:i18n>
-                                                  </xrx:description>
-                                                  <xrx:example>
-                                                  <xrx:i18n>
+                                                </xrx:i18n>
+                                            </xrx:description>
+                                            <xrx:example>
+                                                <xrx:i18n>
                                                   <xrx:key>cei_issued_date_example</xrx:key>
                                                   <xrx:default>&lt;cei:date value="16091001"&gt;1609
                                                   Oktober 1&lt;/cei:date&gt;</xrx:default>
-                                                  </xrx:i18n>
-                                                  </xrx:example>
-                                                </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:element>
-                                        <xs:element ref="dateRange">
-                                            <xs:annotation>
-                                                <xs:appinfo source="EditVDU">
-                                                  <xrxe:min-occur>0</xrxe:min-occur>
-                                                  <xrxe:max-occur>1</xrxe:max-occur>
-                                                </xs:appinfo>
-                                            </xs:annotation>
-                                        </xs:element>
-                                    </xs:choice>
-                                </xs:choice>
-                            <xs:attributeGroup ref="standard"/>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="witnessOrig">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Der einzelne Textzeuge
-                                (MOM)</xs:documentation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_witnessOrig</xrx:key>
-                                        <xrx:default>witnessOrig</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:mixed>false</xrxe:mixed>
-                            </xs:appinfo>
-                        </xs:annotation>
-                        <xs:complexType mixed="true">
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xs:element ref="traditioForm">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:min-occur>0</xrxe:min-occur>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:choice>
-                                        <xs:element ref="archIdentifier"/>
-                                        <xs:element ref="msIdentifier"/>
-                                    </xs:choice>
-                                    <xs:element ref="auth"/>
-                                    <xs:element ref="physicalDesc"/>
-                                    <xs:element ref="nota"/>
-                                    <xs:element ref="rubrum"/>
-                                    <xs:element ref="figure">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:relevant>false</xrxe:relevant>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="p"/>
-                                    <!--Erweiterung-->
-                                </xs:choice>
-                            <xs:attributeGroup ref="certainty"/>
-                            <xs:attribute name="type" type="xs:anySimpleType" use="optional"/>
-                            <xs:attribute name="sigil" type="xs:anySimpleType">
+                                                </xrx:i18n>
+                                            </xrx:example>
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:element>
+                                <xs:element ref="dateRange">
+                                    <xs:annotation>
+                                        <xs:appinfo source="EditVDU">
+                                            <xrxe:min-occur>0</xrxe:min-occur>
+                                            <xrxe:max-occur>1</xrxe:max-occur>
+                                        </xs:appinfo>
+                                    </xs:annotation>
+                                </xs:element>
+                            </xs:choice>
+                        </xs:choice>
+                        <xs:attributeGroup ref="standard"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="witnessOrig">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Der einzelne Textzeuge
+                            (MOM)</xs:documentation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_witnessOrig</xrx:key>
+                                    <xrx:default>witnessOrig</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:mixed>false</xrxe:mixed>
+                        </xs:appinfo>
+                    </xs:annotation>
+                    <xs:complexType mixed="true">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:element ref="traditioForm">
                                 <xs:annotation>
-                                    <xs:documentation xml:lang="deu"> P5 sieht dafür das Attribut id
-                                        vor. Diese Lösung ist sowohl dem Element, als auch dem
-                                        Attribut vorzuziehen. [strict!] </xs:documentation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:min-occur>0</xrxe:min-occur>
+                                    </xs:appinfo>
                                 </xs:annotation>
-                            </xs:attribute>
-                            <xs:attribute name="sameAs" type="xs:anySimpleType" use="optional"/>
-                            <xs:attributeGroup ref="standard"/>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element ref="witListPar"/>
-                    <xs:element name="diplomaticAnalysis">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_diplomaticAnalysis</xrx:key>
-                                        <xrx:default>diplomatic analysis</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:mixed>false</xrxe:mixed>
-                            </xs:appinfo>
-                            <xs:documentation xml:lang="deu"> Enthält Bemerkungen zur diplomatischen
-                                Kritik der Urkunde, die formale Beobachtungen der inneren wie
-                                äußeren Merkmale ebenso wie inhaltliche Überlegungen enthalten kann. </xs:documentation>
-                            <xs:documentation xml:lang="eng"> contains a diplomatic analysis of the
-                                document, formal critics or critics by the content.
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType mixed="true">
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                    <xs:element name="listBibl">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
-                                                  <xrx:key>cei_listBibl</xrx:key>
-                                                  <xrx:default>listBibl</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                                <xrxe:mixed>false</xrxe:mixed>
-                                            </xs:appinfo>
-                                            <xs:documentation xml:lang="deu"> undifferenzierte
-                                                Bibliographische Auflistung von Titeln, die die
-                                                Urkunde betreffen.. </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType mixed="true">
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:choice>
-                                                  <xs:element minOccurs="0" ref="ref"/>
-                                                  <xs:element ref="bibl"/>
-                                                  </xs:choice>
-                                                </xs:choice>
-                                            <xs:attribute name="type"/>
-                                            <!--Erweiterung-->
-                                            <xs:attributeGroup ref="standard"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="listBiblEdition">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
-                                                  <xrx:key>cei_listBiblEdition</xrx:key>
-                                                  <xrx:default>listBiblEdition</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                                <xrxe:mixed>false</xrxe:mixed>
-                                            </xs:appinfo>
-                                            <xs:documentation xml:lang="deu"> Bibliographische
-                                                Auflistung der Editionen = listBibl type="print".
-                                            </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType mixed="true">
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:choice>
-                                                  <xs:element minOccurs="0" ref="ref"/>
-                                                  <xs:element ref="bibl"/>
-                                                  </xs:choice>
-                                                </xs:choice>
-                                            <xs:attributeGroup ref="standard"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="listBiblRegest">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
-                                                  <xrx:key>cei_listBiblRegest</xrx:key>
-                                                  <xrx:default>listBiblRegest</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                                <xrxe:mixed>false</xrxe:mixed>
-                                            </xs:appinfo>
-                                            <xs:documentation xml:lang="deu"> Bibliographische
-                                                Auflistungen = listBibl type="regesta".
-                                            </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType mixed="true">
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:choice>
-                                                  <xs:element minOccurs="0" ref="ref"/>
-                                                  <xs:element ref="bibl"/>
-                                                  </xs:choice>
-                                                </xs:choice>
-                                            <xs:attributeGroup ref="standard"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="listBiblFaksimile">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
-                                                  <xrx:key>cei_listBiblFaksimile</xrx:key>
-                                                  <xrx:default>listBiblFaksimile</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                                <xrxe:mixed>false</xrxe:mixed>
-                                            </xs:appinfo>
-                                            <xs:documentation xml:lang="deu"> Bibliographische
-                                                Auflistung der Faksimiles = listBibl
-                                                type="facsimilia" </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType mixed="true">
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:choice>
-                                                  <xs:element minOccurs="0" ref="ref"/>
-                                                  <xs:element ref="bibl"/>
-                                                  </xs:choice>
-                                                </xs:choice>
-                                            <xs:attributeGroup ref="standard"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element name="listBiblErw">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:label>
-                                                  <xrx:i18n>
-                                                  <xrx:key>cei_listBiblErw</xrx:key>
-                                                  <xrx:default>listBiblErw</xrx:default>
-                                                  </xrx:i18n>
-                                                </xrxe:label>
-                                                <xrxe:mixed>false</xrxe:mixed>
-                                            </xs:appinfo>
-                                            <xs:documentation xml:lang="deu"> Bibliographische
-                                                Auflistung der Erwähnungen = listBibl type="studies"
-                                            </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType mixed="true">
-                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                                  <xs:choice>
-                                                  <xs:element minOccurs="0" ref="ref"/>
-                                                  <xs:element ref="bibl"/>
-                                                  </xs:choice>
-                                                </xs:choice>
-                                            <xs:attributeGroup ref="standard"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                    <xs:element ref="p" maxOccurs="unbounded">
-                                        <xs:annotation>
-                                            <xs:appinfo source="EditVDU">
-                                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                                            </xs:appinfo>
-                                        </xs:annotation>
-                                    </xs:element>
-                                    <xs:element ref="quoteOriginaldatierung"/>
-                                    <xs:element ref="nota"/>
-                                    <xs:element ref="rubrum"/>
-                                    <xs:element ref="divNotes"/>
-                                    <xs:element ref="incipit"/>
-                                </xs:choice>
-                            <xs:attributeGroup ref="standard"/>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="lang_MOM">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_lang_MOM</xrx:key>
-                                        <xrx:default>lang_MOM</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:min-occur>0</xrxe:min-occur>
-                                <xrxe:type-type>simpleType</xrxe:type-type>
-                                <xrxe:mixed>false</xrxe:mixed>
-                                <xrxe:control-control>input</xrxe:control-control>
-                            </xs:appinfo>
-                            <xs:documentation> MOM-spezifisch: Eigentlich tenor@lang
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType mixed="true">
-                            <xs:attributeGroup ref="standard"/>
-                        </xs:complexType>
-                    </xs:element>
-                </xs:choice>
+                            </xs:element>
+                            <xs:choice>
+                                <xs:element ref="archIdentifier"/>
+                                <xs:element ref="msIdentifier"/>
+                            </xs:choice>
+                            <xs:element ref="auth"/>
+                            <xs:element ref="physicalDesc"/>
+                            <xs:element ref="nota"/>
+                            <xs:element ref="rubrum"/>
+                            <xs:element ref="figure">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:relevant>false</xrxe:relevant>
+                                    </xs:appinfo>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element ref="p"/>
+                            <!--Erweiterung-->
+                        </xs:choice>
+                        <xs:attributeGroup ref="certainty"/>
+                        <xs:attribute name="type" type="xs:anySimpleType" use="optional"/>
+                        <xs:attribute name="sigil" type="xs:anySimpleType">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="deu"> P5 sieht dafür das Attribut id
+                                    vor. Diese Lösung ist sowohl dem Element, als auch dem Attribut
+                                    vorzuziehen. [strict!] </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="sameAs" type="xs:anySimpleType" use="optional"/>
+                        <xs:attributeGroup ref="standard"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element ref="witListPar"/>
+                <xs:element name="diplomaticAnalysis">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_diplomaticAnalysis</xrx:key>
+                                    <xrx:default>diplomatic analysis</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:mixed>false</xrxe:mixed>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="deu"> Enthält Bemerkungen zur diplomatischen
+                            Kritik der Urkunde, die formale Beobachtungen der inneren wie äußeren
+                            Merkmale ebenso wie inhaltliche Überlegungen enthalten kann. </xs:documentation>
+                        <xs:documentation xml:lang="eng"> contains a diplomatic analysis of the
+                            document, formal critics or critics by the content. </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType mixed="true">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:element name="listBibl">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_listBibl</xrx:key>
+                                                <xrx:default>listBibl</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:mixed>false</xrxe:mixed>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> undifferenzierte
+                                        Bibliographische Auflistung von Titeln, die die Urkunde
+                                        betreffen.. </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                        <xs:choice>
+                                            <xs:element minOccurs="0" ref="ref"/>
+                                            <xs:element ref="bibl"/>
+                                        </xs:choice>
+                                    </xs:choice>
+                                    <xs:attributeGroup ref="standard"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="listBiblEdition">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_listBiblEdition</xrx:key>
+                                                <xrx:default>listBiblEdition</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:mixed>false</xrxe:mixed>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> Bibliographische Auflistung
+                                        der Editionen = listBibl type="print". </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                        <xs:choice>
+                                            <xs:element minOccurs="0" ref="ref"/>
+                                            <xs:element ref="bibl"/>
+                                        </xs:choice>
+                                    </xs:choice>
+                                    <xs:attributeGroup ref="standard"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="listBiblRegest">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_listBiblRegest</xrx:key>
+                                                <xrx:default>listBiblRegest</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:mixed>false</xrxe:mixed>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> Bibliographische Auflistungen
+                                        = listBibl type="regesta". </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                        <xs:choice>
+                                            <xs:element minOccurs="0" ref="ref"/>
+                                            <xs:element ref="bibl"/>
+                                        </xs:choice>
+                                    </xs:choice>
+                                    <xs:attributeGroup ref="standard"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="listBiblFaksimile">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_listBiblFaksimile</xrx:key>
+                                                <xrx:default>listBiblFaksimile</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:mixed>false</xrxe:mixed>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> Bibliographische Auflistung
+                                        der Faksimiles = listBibl type="facsimilia"
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                        <xs:choice>
+                                            <xs:element minOccurs="0" ref="ref"/>
+                                            <xs:element ref="bibl"/>
+                                        </xs:choice>
+                                    </xs:choice>
+                                    <xs:attributeGroup ref="standard"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="listBiblErw">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_listBiblErw</xrx:key>
+                                                <xrx:default>listBiblErw</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:mixed>false</xrxe:mixed>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> Bibliographische Auflistung
+                                        der Erwähnungen = listBibl type="studies"
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType mixed="true">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                        <xs:choice>
+                                            <xs:element minOccurs="0" ref="ref"/>
+                                            <xs:element ref="bibl"/>
+                                        </xs:choice>
+                                    </xs:choice>
+                                    <xs:attributeGroup ref="standard"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element ref="p" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:max-occur>unbounded</xrxe:max-occur>
+                                    </xs:appinfo>
+                                </xs:annotation>
+                            </xs:element>
+                            <xs:element ref="quoteOriginaldatierung"/>
+                            <xs:element ref="nota"/>
+                            <xs:element ref="rubrum"/>
+                            <xs:element ref="divNotes"/>
+                            <xs:element ref="incipit"/>
+                        </xs:choice>
+                        <xs:attributeGroup ref="standard"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="lang_MOM">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_lang_MOM</xrx:key>
+                                    <xrx:default>lang_MOM</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:min-occur>0</xrxe:min-occur>
+                            <xrxe:type-type>simpleType</xrxe:type-type>
+                            <xrxe:mixed>false</xrxe:mixed>
+                            <xrxe:control-control>input</xrxe:control-control>
+                        </xs:appinfo>
+                        <xs:documentation> MOM-spezifisch: Eigentlich tenor@lang </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType mixed="true">
+                        <xs:attributeGroup ref="standard"/>
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1016,12 +1016,12 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="class"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:group ref="layout"/>
-                    <xs:element ref="recipient"/>
-                    <xs:element ref="issuer"/>
-                </xs:choice>
+                <xs:element ref="class"/>
+                <xs:group ref="Sachliches"/>
+                <xs:group ref="layout"/>
+                <xs:element ref="recipient"/>
+                <xs:element ref="issuer"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1057,9 +1057,9 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:group ref="layout"/>
-                                <xs:group ref="biblArch"/>
-                            </xs:choice>
+                            <xs:group ref="layout"/>
+                            <xs:group ref="biblArch"/>
+                        </xs:choice>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1077,9 +1077,9 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:element ref="ref"/>
-                                <xs:element ref="bibl"/>
-                            </xs:choice>
+                            <xs:element ref="ref"/>
+                            <xs:element ref="bibl"/>
+                        </xs:choice>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1099,8 +1099,8 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:element ref="desc"/>
-                            </xs:choice>
+                            <xs:element ref="desc"/>
+                        </xs:choice>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1212,8 +1212,8 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="witness"/>
-                </xs:choice>
+                <xs:element ref="witness"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1235,25 +1235,25 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="traditioForm">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:min-occur>0</xrxe:min-occur>
-                            </xs:appinfo>
-                        </xs:annotation>
-                    </xs:element>
-                    <xs:choice>
-                        <xs:element ref="archIdentifier"/>
-                        <xs:element ref="msIdentifier"/>
-                    </xs:choice>
-                    <xs:element ref="auth"/>
-                    <xs:element ref="physicalDesc"/>
-                    <xs:element ref="nota"/>
-                    <xs:element ref="rubrum"/>
-                    <xs:element ref="figure"/>
-                    <xs:group ref="layout"/>
-                    <xs:group ref="textualElements"/>
+                <xs:element ref="traditioForm">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:min-occur>0</xrxe:min-occur>
+                        </xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+                <xs:choice>
+                    <xs:element ref="archIdentifier"/>
+                    <xs:element ref="msIdentifier"/>
                 </xs:choice>
+                <xs:element ref="auth"/>
+                <xs:element ref="physicalDesc"/>
+                <xs:element ref="nota"/>
+                <xs:element ref="rubrum"/>
+                <xs:element ref="figure"/>
+                <xs:group ref="layout"/>
+                <xs:group ref="textualElements"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="id"/>
             <xs:attribute name="n" type="xs:anySimpleType">
@@ -1287,7 +1287,9 @@
                 entnehmen oder in der profileDesc zu dokumentieren. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="layout"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1306,7 +1308,10 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element ref="foreign"/><xs:group ref="layout"/></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="foreign"/>
+                <xs:group ref="layout"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1324,8 +1329,8 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="index"/>
-                </xs:choice>
+                <xs:element ref="index"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1348,11 +1353,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="notariusDesc"/>
-                    <xs:element ref="sealDesc"/>
-                    <xs:element ref="subscriptio"/>
-                    <xs:element ref="chirograph"/>
-                </xs:choice>
+                <xs:element ref="notariusDesc"/>
+                <xs:element ref="sealDesc"/>
+                <xs:element ref="subscriptio"/>
+                <xs:element ref="chirograph"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1375,11 +1380,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="seal"/>
-                    <xs:element ref="legend"/>
-                    <xs:group ref="layout"/>
-                    <xs:element ref="index"/>
-                </xs:choice>
+                <xs:element ref="seal"/>
+                <xs:element ref="legend"/>
+                <xs:group ref="layout"/>
+                <xs:element ref="index"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1407,14 +1412,14 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="layout"/>
-                    <xs:element ref="sigillant"/>
-                    <xs:element ref="legend"/>
-                    <xs:element ref="sealDimensions"/>
-                    <xs:element ref="sealMaterial"/>
-                    <xs:element ref="sealCondition"/>
-                    <xs:element ref="index"/>
-                </xs:choice>
+                <xs:group ref="layout"/>
+                <xs:element ref="sigillant"/>
+                <xs:element ref="legend"/>
+                <xs:element ref="sealDimensions"/>
+                <xs:element ref="sealMaterial"/>
+                <xs:element ref="sealCondition"/>
+                <xs:element ref="index"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1442,8 +1447,8 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attribute name="place"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1471,9 +1476,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="quote"/>
-                    <xs:group ref="Sachauszeichnung"/>
-                </xs:choice>
+                <xs:element ref="quote"/>
+                <xs:group ref="Sachauszeichnung"/>
+            </xs:choice>
             <xs:attributeGroup ref="reg"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1495,27 +1500,26 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="notariusSub">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:max-occur>unbounded</xrxe:max-occur>
-                            </xs:appinfo>
-                        </xs:annotation>
-                    </xs:element>
-                    <xs:element ref="notariusSign"/>
-                    <xs:element ref="quote"/>
-                    <xs:element ref="persName"/>
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu"> Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:element ref="index"/>
-                    <xs:element ref="num"/>
+                <xs:element ref="notariusSub">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:max-occur>unbounded</xrxe:max-occur>
+                        </xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element ref="notariusSign"/>
+                <xs:element ref="quote"/>
+                <xs:element ref="persName"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu"> Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:element ref="index"/>
+                <xs:element ref="num"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1568,9 +1572,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attribute name="position" type="xs:anySimpleType" use="optional"/>
             <xs:attributeGroup ref="lang"/>
@@ -1598,9 +1602,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1623,11 +1627,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="material"/>
-                    <xs:element ref="dimensions"/>
-                    <xs:element ref="condition"/>
-                    <xs:element ref="decoDesc"/>
-                </xs:choice>
+                <xs:element ref="material"/>
+                <xs:element ref="dimensions"/>
+                <xs:element ref="condition"/>
+                <xs:element ref="decoDesc"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1648,8 +1652,8 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="p"/>
-                </xs:choice>
+                <xs:element ref="p"/>
+            </xs:choice>
             <xs:attributeGroup ref="reference"/>
         </xs:complexType>
     </xs:element>
@@ -1669,60 +1673,64 @@
                 Elementen) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element name="width" type="xs:string">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_width</xrx:key>
-                                        <xrx:default>width</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:menu-item>
-                                    <xrx:i18n>
-                                        <xrx:key>textual-tradition</xrx:key>
-                                        <xrx:default>textual tradition</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:menu-item>
-                            </xs:appinfo>
-                        </xs:annotation>
-                    </xs:element><xs:element name="height" type="xs:string">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_height</xrx:key>
-                                        <xrx:default>height</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:menu-item>
-                                    <xrx:i18n>
-                                        <xrx:key>textual-tradition</xrx:key>
-                                        <xrx:default>textual tradition</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:menu-item>
-                            </xs:appinfo>
-                        </xs:annotation>
-                    </xs:element><xs:element name="plica" type="xs:string">
-                        <xs:annotation>
-                            <xs:appinfo source="EditVDU">
-                                <xrxe:label>
-                                    <xrx:i18n>
-                                        <xrx:key>cei_plica</xrx:key>
-                                        <xrx:default>plica</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:label>
-                                <xrxe:menu-item>
-                                    <xrx:i18n>
-                                        <xrx:key>textual-tradition</xrx:key>
-                                        <xrx:default>textual tradition</xrx:default>
-                                    </xrx:i18n>
-                                </xrxe:menu-item>
-                            </xs:appinfo>
-                            <xs:documentation xml:lang="eng"> describes the depth of the fold used
-                                to secure the threads for the seal </xs:documentation>
-                        </xs:annotation>
-                    </xs:element></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="width" type="xs:string">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_width</xrx:key>
+                                    <xrx:default>width</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:menu-item>
+                                <xrx:i18n>
+                                    <xrx:key>textual-tradition</xrx:key>
+                                    <xrx:default>textual tradition</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:menu-item>
+                        </xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="height" type="xs:string">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_height</xrx:key>
+                                    <xrx:default>height</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:menu-item>
+                                <xrx:i18n>
+                                    <xrx:key>textual-tradition</xrx:key>
+                                    <xrx:default>textual tradition</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:menu-item>
+                        </xs:appinfo>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="plica" type="xs:string">
+                    <xs:annotation>
+                        <xs:appinfo source="EditVDU">
+                            <xrxe:label>
+                                <xrx:i18n>
+                                    <xrx:key>cei_plica</xrx:key>
+                                    <xrx:default>plica</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:label>
+                            <xrxe:menu-item>
+                                <xrx:i18n>
+                                    <xrx:key>textual-tradition</xrx:key>
+                                    <xrx:default>textual tradition</xrx:default>
+                                </xrx:i18n>
+                            </xrxe:menu-item>
+                        </xs:appinfo>
+                        <xs:documentation xml:lang="eng"> describes the depth of the fold used to
+                            secure the threads for the seal </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
             <xs:attribute name="type" type="xs:string"/>
             <!--Erweiterung-->
@@ -1773,7 +1781,10 @@
                 written </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element ref="foreign"/><xs:group ref="layout"/></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element ref="foreign"/>
+                <xs:group ref="layout"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1826,9 +1837,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attribute name="position" type="xs:anySimpleType" use="optional"/>
             <xs:attributeGroup ref="lang"/>
@@ -1858,19 +1869,19 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="settlement"/>
-                    <xs:element ref="region"/>
-                    <xs:element ref="country"/>
-                    <xs:element ref="institution"/>
-                    <xs:element ref="repository"/>
-                    <xs:element ref="ref"/>
-                    <xs:element ref="arch"/>
-                    <xs:element ref="archFond"/>
-                    <xs:element ref="idno"/>
-                    <xs:element ref="scope"/>
-                    <xs:element ref="altIdentifier"/>
-                    <xs:element ref="hi"/>
-                </xs:choice>
+                <xs:element ref="settlement"/>
+                <xs:element ref="region"/>
+                <xs:element ref="country"/>
+                <xs:element ref="institution"/>
+                <xs:element ref="repository"/>
+                <xs:element ref="ref"/>
+                <xs:element ref="arch"/>
+                <xs:element ref="archFond"/>
+                <xs:element ref="idno"/>
+                <xs:element ref="scope"/>
+                <xs:element ref="altIdentifier"/>
+                <xs:element ref="hi"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1890,19 +1901,19 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:choice>
-                        <xs:element ref="settlement"/>
-                        <xs:element ref="region"/>
-                        <xs:element ref="country"/>
-                        <xs:element ref="institution"/>
-                        <xs:element ref="repository"/>
-                        <xs:element minOccurs="0" ref="arch"/>
-                    </xs:choice>
-                    <xs:element ref="archFond"/>
-                    <xs:element ref="idno"/>
-                    <xs:element ref="scope"/>
-                    <xs:element ref="note"/>
+                <xs:choice>
+                    <xs:element ref="settlement"/>
+                    <xs:element ref="region"/>
+                    <xs:element ref="country"/>
+                    <xs:element ref="institution"/>
+                    <xs:element ref="repository"/>
+                    <xs:element minOccurs="0" ref="arch"/>
                 </xs:choice>
+                <xs:element ref="archFond"/>
+                <xs:element ref="idno"/>
+                <xs:element ref="scope"/>
+                <xs:element ref="note"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
             <xs:attributeGroup ref="type"/>
         </xs:complexType>
@@ -1928,7 +1939,9 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="layout"/>
+            </xs:choice>
             <xs:attributeGroup ref="expan"/>
             <xs:attributeGroup ref="key"/>
             <xs:attributeGroup ref="lang"/>
@@ -2008,14 +2021,14 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="settlement"/>
-                    <xs:element ref="region"/>
-                    <xs:element ref="country"/>
-                    <xs:element ref="institution"/>
-                    <xs:element ref="repository"/>
-                    <xs:element ref="idno"/>
-                    <xs:element ref="scope"/>
-                </xs:choice>
+                <xs:element ref="settlement"/>
+                <xs:element ref="region"/>
+                <xs:element ref="country"/>
+                <xs:element ref="institution"/>
+                <xs:element ref="repository"/>
+                <xs:element ref="idno"/>
+                <xs:element ref="scope"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2094,10 +2107,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:element ref="num"/>
-                    <xs:element ref="note"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:element ref="num"/>
+                <xs:element ref="note"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2119,11 +2132,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:group ref="Formular"/>
-                    <xs:element ref="pTenor"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:group ref="Formular"/>
+                <xs:element ref="pTenor"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -2148,18 +2161,18 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="archIdentifier"/>
-                    <xs:element ref="msIdentifier"/>
-                    <xs:element ref="bibl"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="a"/>
-                    <xs:element ref="hi"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="sup"/>
-                    <xs:element ref="scope"/>
-                    <!--Erweiterung-->
-                </xs:choice>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="archIdentifier"/>
+                <xs:element ref="msIdentifier"/>
+                <xs:element ref="bibl"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="a"/>
+                <xs:element ref="hi"/>
+                <xs:element ref="c"/>
+                <xs:element ref="sup"/>
+                <xs:element ref="scope"/>
+                <!--Erweiterung-->
+            </xs:choice>
             <xs:attributeGroup ref="resp"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2191,12 +2204,12 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Formular"/>
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="recipient"/>
-                    <xs:element ref="issuer"/>
-                </xs:choice>
+                <xs:group ref="Formular"/>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="recipient"/>
+                <xs:element ref="issuer"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2245,10 +2258,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2277,10 +2290,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2308,10 +2321,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2339,10 +2352,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2371,10 +2384,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2403,12 +2416,12 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="rogatio"/>
-                    <xs:element ref="intercessio"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="rogatio"/>
+                <xs:element ref="intercessio"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2437,10 +2450,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2469,10 +2482,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2501,10 +2514,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2532,10 +2545,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2564,9 +2577,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2595,11 +2608,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element minOccurs="0" maxOccurs="unbounded" ref="setPhrase"/>
-                    <xs:element minOccurs="0" maxOccurs="unbounded" ref="notariusSub"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="setPhrase"/>
+                <xs:element minOccurs="0" maxOccurs="unbounded" ref="notariusSub"/>
+            </xs:choice>
             <xs:attributeGroup ref="type">
                 <xs:annotation>
                     <xs:documentation xml:lang="deu"> Die Unterscheidung in "Signumzeile",
@@ -2634,10 +2647,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2658,10 +2671,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="setPhrase"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="setPhrase"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2693,9 +2706,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2725,9 +2738,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2854,19 +2867,19 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="hi"/>
-                    <xs:element ref="handShift"/>
-                    <xs:element ref="pict"/>
-                    <xs:element ref="pc"/>
-                    <!--Erweiterung-->
-                    <xs:element ref="w"/>
-                    <!--Erweiterung-->
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="hi"/>
+                <xs:element ref="handShift"/>
+                <xs:element ref="pict"/>
+                <xs:element ref="pc"/>
+                <!--Erweiterung-->
+                <xs:element ref="w"/>
+                <!--Erweiterung-->
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attribute name="extent" type="xs:anySimpleType"/>
             <xs:attribute name="degree" type="xs:anySimpleType">
                 <xs:annotation>
@@ -2921,13 +2934,13 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="handShift"/>
-                    <xs:element ref="pict"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="handShift"/>
+                <xs:element ref="pict"/>
+            </xs:choice>
             <xs:attribute name="extent" type="xs:anySimpleType">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -3043,22 +3056,20 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:group ref="Sachauszeichnung"/>
-                                <xs:group ref="biblArch"/>
-                                <xs:group ref="layout"/>
-                                <xs:group ref="reference"/>
-                                <xs:group ref="textualElements"/>
-                                <xs:element ref="w"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="pc"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="space"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="damage"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="supplied"/>
-                                <!--Erweiterung-->
-                            </xs:choice>
+                            <xs:group ref="Sachauszeichnung"/>
+                            <xs:group ref="biblArch"/>
+                            <xs:group ref="layout"/>
+                            <xs:group ref="reference"/>
+                            <xs:group ref="textualElements"/>
+                            <xs:element ref="w"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="pc"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="space"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="supplied"/>
+                            <!--Erweiterung-->
+                        </xs:choice>
                         <xs:attributeGroup ref="wit"/>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
@@ -3077,18 +3088,18 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:element ref="w"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="add"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="app"/>
-                                <!--Erweiterung-->
-                                <xs:element ref="foreign"/>
-                                <!--Erweiterung-->
-                                <xs:group ref="biblArch"/>
-                                <xs:group ref="layout"/>
-                                <xs:group ref="reference"/>
-                            </xs:choice>
+                            <xs:element ref="w"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="add"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="app"/>
+                            <!--Erweiterung-->
+                            <xs:element ref="foreign"/>
+                            <!--Erweiterung-->
+                            <xs:group ref="biblArch"/>
+                            <xs:group ref="layout"/>
+                            <xs:group ref="reference"/>
+                        </xs:choice>
                         <xs:attribute name="type"/>
                         <!--Erweiterung-->
                         <xs:attributeGroup ref="wit"/>
@@ -3122,15 +3133,15 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="add"/>
-                    <xs:element ref="supplied"/>
-                    <xs:element ref="corr"/>
-                    <xs:element ref="sic"/>
-                    <xs:element ref="damage"/>
-                </xs:choice>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="add"/>
+                <xs:element ref="supplied"/>
+                <xs:element ref="corr"/>
+                <xs:element ref="sic"/>
+                <xs:element ref="damage"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="abbr">
                 <xs:annotation>
@@ -3165,14 +3176,14 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="add"/>
-                    <xs:element ref="supplied"/>
-                    <xs:element ref="handShift"/>
-                    <xs:group ref="Referenz"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="add"/>
+                <xs:element ref="supplied"/>
+                <xs:element ref="handShift"/>
+                <xs:group ref="Referenz"/>
+            </xs:choice>
             <xs:attribute name="corr">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -3206,16 +3217,16 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="sic"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="damage"/>
-                    <xs:element ref="handShift"/>
-                    <xs:group ref="Sachauszeichnung"/>
-                    <xs:group ref="Referenz"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="sic"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="c"/>
+                <xs:element ref="damage"/>
+                <xs:element ref="handShift"/>
+                <xs:group ref="Sachauszeichnung"/>
+                <xs:group ref="Referenz"/>
+            </xs:choice>
             <xs:attribute name="sic"/>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
@@ -3245,16 +3256,16 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="add"/>
-                    <xs:element ref="supplied"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="damage"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="sic"/>
-                    <xs:group ref="Referenz"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="add"/>
+                <xs:element ref="supplied"/>
+                <xs:element ref="c"/>
+                <xs:element ref="damage"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="sic"/>
+                <xs:group ref="Referenz"/>
+            </xs:choice>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3282,20 +3293,20 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="expan"/>
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="sic"/>
-                    <xs:element ref="corr"/>
-                    <xs:element ref="del"/>
-                    <xs:element ref="damage"/>
-                    <xs:element ref="handShift"/>
-                    <xs:element ref="w"/>
-                    <!--Erweiterung-->
-                    <xs:group ref="Sachauszeichnung"/>
-                    <xs:group ref="Referenz"/>
-                </xs:choice>
+                <xs:element ref="expan"/>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="sic"/>
+                <xs:element ref="corr"/>
+                <xs:element ref="del"/>
+                <xs:element ref="damage"/>
+                <xs:element ref="handShift"/>
+                <xs:element ref="w"/>
+                <!--Erweiterung-->
+                <xs:group ref="Sachauszeichnung"/>
+                <xs:group ref="Referenz"/>
+            </xs:choice>
             <xs:attribute name="status"/>
             <!--Erweiterung-->
             <xs:attributeGroup ref="transcription"/>
@@ -3326,18 +3337,18 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="c"/>
-                    <xs:element ref="lb"/>
-                    <xs:element ref="pb"/>
-                    <xs:element ref="damage"/>
-                    <xs:element ref="expan"/>
-                    <xs:element ref="w"/>
-                    <!--Erweiterung-->
-                    <xs:element ref="pc"/>
-                    <!--Erweiterung-->
-                    <xs:group ref="Sachauszeichnung"/>
-                    <xs:group ref="Referenz"/>
-                </xs:choice>
+                <xs:element ref="c"/>
+                <xs:element ref="lb"/>
+                <xs:element ref="pb"/>
+                <xs:element ref="damage"/>
+                <xs:element ref="expan"/>
+                <xs:element ref="w"/>
+                <!--Erweiterung-->
+                <xs:element ref="pc"/>
+                <!--Erweiterung-->
+                <xs:group ref="Sachauszeichnung"/>
+                <xs:group ref="Referenz"/>
+            </xs:choice>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -3570,10 +3581,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:group ref="Formular"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:group ref="Formular"/>
+            </xs:choice>
             <xs:attributeGroup ref="rend"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3713,12 +3724,12 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                    <xs:element ref="bibl"/>
-                    <xs:element ref="archIdentifier"/>
-                    <xs:element ref="msIdentifier"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+                <xs:element ref="bibl"/>
+                <xs:element ref="archIdentifier"/>
+                <xs:element ref="msIdentifier"/>
+            </xs:choice>
             <xs:attribute name="place"/>
             <xs:attributeGroup ref="id"/>
             <xs:attributeGroup ref="type"/>
@@ -3834,8 +3845,8 @@
         </xs:annotation>
         <xs:complexType>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="textualElements"/>
-                </xs:choice>
+                <xs:group ref="textualElements"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3855,8 +3866,8 @@
         </xs:annotation>
         <xs:complexType>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="note"/>
-                </xs:choice>
+                <xs:element ref="note"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -3885,9 +3896,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachauszeichnung"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachauszeichnung"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3953,11 +3964,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachauszeichnung"/>
-                    <xs:group ref="reference"/>
-                    <xs:element ref="foreign"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachauszeichnung"/>
+                <xs:group ref="reference"/>
+                <xs:element ref="foreign"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -4035,9 +4046,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachliches"/>
-                </xs:choice>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachliches"/>
+            </xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -4077,10 +4088,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="num"/>
-                    <xs:element ref="index"/>
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="num"/>
+                <xs:element ref="index"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -4108,11 +4119,11 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="w"/>
-                    <!--Erweiterung-->
-                    <xs:element ref="pc"/>
-                    <!--Erweiterung-->
-                </xs:choice>
+                <xs:element ref="w"/>
+                <!--Erweiterung-->
+                <xs:element ref="pc"/>
+                <!--Erweiterung-->
+            </xs:choice>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="value"/>
             <xs:attributeGroup ref="lang"/>
@@ -4179,9 +4190,9 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attribute name="indexName">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -4250,13 +4261,13 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="num"/>
-                    <xs:group ref="Originalbefund"/>
-                    <xs:element ref="ref"/>
-                    <xs:element ref="figure"/>
-                    <!-- Erweiterung -->
-                </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="num"/>
+                <xs:group ref="Originalbefund"/>
+                <xs:element ref="ref"/>
+                <xs:element ref="figure"/>
+                <!-- Erweiterung -->
+            </xs:choice>
             <xs:attributeGroup ref="date"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -4285,10 +4296,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="num"/>
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="num"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attribute name="from" type="normalizedDateValue" use="required">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -4371,19 +4382,18 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="persName"/>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="persName"/>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="identification"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
@@ -4411,23 +4421,22 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="persName"/>
-                        <xs:element ref="orgName"/>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                        <xs:element ref="forename"/>
-                        <xs:element ref="surname"/>
-                        <xs:element ref="rolename"/>
-                    </xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="persName"/>
+                    <xs:element ref="orgName"/>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
+                    <xs:element ref="forename"/>
+                    <xs:element ref="surname"/>
+                    <xs:element ref="rolename"/>
                 </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="identification"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
@@ -4455,10 +4464,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4486,21 +4495,20 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="rolename"/>
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:element ref="orgName"/>
-                    <!--Erweiterung-->
-                    <xs:group ref="Originalbefund"/>
+                <xs:element ref="rolename"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:element ref="orgName"/>
+                <!--Erweiterung-->
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4528,12 +4536,12 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
-                    <xs:group ref="Sachauszeichnung"/>
-                    <!--Erweiterung-->
-                </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+                <xs:group ref="Sachauszeichnung"/>
+                <!--Erweiterung-->
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4564,19 +4572,18 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="persName"/>
-                    <xs:element ref="orgName"/>
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:group ref="Originalbefund"/>
+                <xs:element ref="foreign"/>
+                <xs:element ref="persName"/>
+                <xs:element ref="orgName"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4606,20 +4613,19 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="persName"/>
-                    <xs:element ref="orgName"/>
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
+                <xs:element ref="persName"/>
+                <xs:element ref="orgName"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4646,18 +4652,17 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:group ref="Originalbefund"/>
-                    <xs:choice>
-                        <xs:annotation>
-                            <xs:documentation xml:lang="deu">Geographische Angaben
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:element ref="placeName"/>
-                        <xs:element ref="geogName"/>
-                    </xs:choice>
-                    <xs:element ref="persName"/>
+                <xs:element ref="foreign"/>
+                <xs:group ref="Originalbefund"/>
+                <xs:choice>
+                    <xs:annotation>
+                        <xs:documentation xml:lang="deu">Geographische Angaben </xs:documentation>
+                    </xs:annotation>
+                    <xs:element ref="placeName"/>
+                    <xs:element ref="geogName"/>
                 </xs:choice>
+                <xs:element ref="persName"/>
+            </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4769,15 +4774,15 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="index"/>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:element ref="placeName"/>
-                    <!--Erweiterung-->
-                    <xs:element ref="persName"/>
-                    <!--Erweiterung-->
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="index"/>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:element ref="placeName"/>
+                <!--Erweiterung-->
+                <xs:element ref="persName"/>
+                <!--Erweiterung-->
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="key"/>
             <xs:attributeGroup ref="geog"/>
             <xs:attributeGroup ref="type"/>
@@ -4809,10 +4814,10 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="note"/>
-                    <xs:group ref="Originalbefund"/>
-                </xs:choice>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <xs:group ref="Originalbefund"/>
+            </xs:choice>
             <xs:attributeGroup ref="geog"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
@@ -4874,18 +4879,18 @@
                     </xs:annotation>
                     <xs:complexType mixed="true">
                         <xs:choice minOccurs="0" maxOccurs="unbounded">
-                                <xs:element ref="scope"/>
-                                <xs:element name="pubPlace">
-                                    <xs:complexType>
-                                        <xs:simpleContent>
-                                            <xs:extension base="xs:string">
-                                                <xs:attributeGroup ref="standard"/>
-                                            </xs:extension>
-                                        </xs:simpleContent>
-                                    </xs:complexType>
-                                </xs:element>
-                                <xs:group ref="date"/>
-                            </xs:choice>
+                            <xs:element ref="scope"/>
+                            <xs:element name="pubPlace">
+                                <xs:complexType>
+                                    <xs:simpleContent>
+                                        <xs:extension base="xs:string">
+                                            <xs:attributeGroup ref="standard"/>
+                                        </xs:extension>
+                                    </xs:simpleContent>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:group ref="date"/>
+                        </xs:choice>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -4956,12 +4961,14 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:group ref="layout"/>
-                    <xs:element ref="foreign"/>
-                    <xs:element ref="quote"/>
-                    <xs:group ref="Referenz"/>
-                    <xs:group ref="BibliographicInformation"/>
-                </xs:choice>
+                <xs:group ref="layout"/>
+                <xs:element ref="foreign"/>
+                <xs:element ref="note"/>
+                <!--Erweiterung-->
+                <xs:element ref="quote"/>
+                <xs:group ref="Referenz"/>
+                <xs:group ref="BibliographicInformation"/>
+            </xs:choice>
             <xs:attribute name="status"/>
             <!--Erweiterung-->
             <xs:attribute name="type"/>
@@ -5107,7 +5114,9 @@
                             <xrx:default>certainty</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"
+                    />
                 </xs:appinfo>
                 <xs:documentation xml:lang="deu"> Für Genauigkeitsangaben z.B. bei Datierungen,
                     werden mit Schlüsselwörtern (zu benennen in der encodingDesc) oder kurzen
@@ -5143,7 +5152,9 @@
                             <xrx:default>reg</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"
+                    />
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
@@ -5174,7 +5185,9 @@
                             <xrx:default>type</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"/>
+                    <xrxe:relevant
+                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"
+                    />
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -1,7 +1,4 @@
-<xs:schema xmlns="http://www.monasterium.net/NS/cei" xmlns:xerces="http://xerces.apache.org"
-    xmlns:xrxe="http://www.monasterium.net/NS/xrxe" xmlns:xrx="http://www.monasterium.net/NS/xrx"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified"
-    elementFormDefault="qualified" targetNamespace="http://www.monasterium.net/NS/cei" id="cei10">
+<?xml version="1.0" encoding="UTF-8"?><xs:schema xmlns="http://www.monasterium.net/NS/cei" xmlns:xerces="http://xerces.apache.org" xmlns:xrxe="http://www.monasterium.net/NS/xrxe" xmlns:xrx="http://www.monasterium.net/NS/xrx" xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="http://www.monasterium.net/NS/cei" id="cei10">
     <xs:element name="cei">
         <xs:annotation>
             <xs:documentation xml:lang="deu"> Wurzelelement für alle Dokumente, die den Regeln der
@@ -26,32 +23,32 @@
                 lang auf ausgewählte Elemente beschränkt (vgl. EditMOM), nota in
                 "diplomaticAnalysis" eingefügt. measure mit num/index und Originalbefund versehen.
                 GV 2006-08-09: seal, witness und alle Subelemente als globale Elemente definiert,
-                den neuen globalen Elementen &lt;menu> vergeben (GV) 2006-07-06: pict zu
+                den neuen globalen Elementen &lt;menu&gt; vergeben (GV) 2006-07-06: pict zu
                 group:Originalbefund hinzugefügt, NotariusSub auch als Teil von group:Formular
                 eingefügt; issuer, recipient auch in der Transkription zulässig (GV) 2006-07-05:
                 lang_MOM in mixed Type true umgewandelt (GV) 2006-06-27: verschiedene
                 Attribut-Korrekturen (GV) 2006-06-26: lang_MOM eingeführt. (GV) 2006-06-21:
                 teiHeader fakultativ, respStmt aus text/front herausgenommen (GV) 2006-06-16:
-                date_sort korrigiert, Attribut b_name zu &lt;text> eingeführt (GV) 2006-06-07:
+                date_sort korrigiert, Attribut b_name zu &lt;text&gt; eingeführt (GV) 2006-06-07:
                 issuer &amp; recipient nur in abstract zugelassen; subelemente von bibl entfernt; a
                 global definiert, appinfo zu settlement, repository und scope global definiert. (GV)
-                2006-05-21: Captions geändert und ein paar Sicherheits &lt;present>no eingefügt.
+                2006-05-21: Captions geändert und ein paar Sicherheits &lt;present&gt;no eingefügt.
                 (GV) 2006-05-18: sourceDescVolltext ergänzt und kleinere editMOM-Ergänzungen (GV)
                 2006-05-17: sourceDesc aufgeräumt; Versuch alle Elemente, die in die Maske kommen,
                 global zu definieren; note aus den Fließtexten geworfen. (GV) 2006-05-16: expan
-                statt abbr für Abkürzung, note/index als eigener Reiter, &lt;caption xml:lang="deu">
-                eingefügt; Attribute (z.B. id/n) mit &lt;present>no&lt;/present> versehen. Menü
-                "Siegelbeschreibung" ergänzt. &lt;sup> in p und abstract zugelassen, aber nicht in
+                statt abbr für Abkürzung, note/index als eigener Reiter, &lt;caption xml:lang="deu"&gt;
+                eingefügt; Attribute (z.B. id/n) mit &lt;present&gt;no&lt;/present&gt; versehen. Menü
+                "Siegelbeschreibung" ergänzt. &lt;sup&gt; in p und abstract zugelassen, aber nicht in
                 Menüs übernommen, denn diese Tags müssen noch nachbearbeitet werden. (GV) 2006-05-11
                 Einige Elemente, die in Fließtextfeldern auftauchen, global definiert (pTenor, a,
-                legend), in einigen Fällen &lt;present>no&lt;/present> eingefügt (group etc.) (GV)
+                legend), in einigen Fällen &lt;present&gt;no&lt;/present&gt; eingefügt (group etc.) (GV)
                 2006-05-09 Knoten, die selber nicht angezeigt werden und keine anzuzeigenden
-                Subknoten haben, sind mit dem Attribut &lt;present>no&lt;/present> in der
+                Subknoten haben, sind mit dem Attribut &lt;present&gt;no&lt;/present&gt; in der
                 EditMOM-appinfo versehen. Alle Elemente, die als Fließtext auftauchen können, sind
                 global definiert. (GV) 2006-05-02 listBibl (listBiblEdition, listBiblRegest,
                 listBiblFaksimile, listBiblErw), sourceDesc (sourceDescRegest), p (p, pTenor)
                 typisiert, um in der Anzeige differenzieren zu können. EditMOM:Auswahlliste
-                eingeführt. (GV) 2006-04-25 Weitere &lt;tab>-hinzugefügt. (GV) 2006-04-06 Innerhalb
+                eingeführt. (GV) 2006-04-25 Weitere &lt;tab&gt;-hinzugefügt. (GV) 2006-04-06 Innerhalb
                 von hi Formular zugelassen; issuer verzweigt wie persName, persName kann auch note
                 enthalten. Weitere Attributlisten plausibler aufgereiht. (GV) 2006-04-05 Reihenfolge
                 der Tenorelemente plausibler angeordnet, hi::target in hi::type korrigiert, ein paar
@@ -103,8 +100,7 @@
                                                 </xs:documentation>
                                             </xs:annotation>
                                             <xs:complexType>
-                                                <xs:sequence>
-                                                  <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:element ref="title"/>
                                                   <xs:element name="author">
                                                   <xs:annotation>
@@ -121,7 +117,6 @@
                                                   </xs:element>
                                                   <xs:element ref="p"/>
                                                   </xs:choice>
-                                                </xs:sequence>
                                                 <xs:attributeGroup ref="standard"/>
                                             </xs:complexType>
                                         </xs:element>
@@ -146,11 +141,9 @@
                                                 </xs:documentation>
                                             </xs:annotation>
                                             <xs:complexType>
-                                                <xs:sequence>
-                                                  <xs:choice minOccurs="0">
+                                                <xs:choice minOccurs="0">
                                                   <xs:element ref="p"/>
                                                   </xs:choice>
-                                                </xs:sequence>
                                                 <xs:attributeGroup ref="standard"/>
                                             </xs:complexType>
                                         </xs:element>
@@ -174,12 +167,10 @@
                                     </xs:documentation>
                                 </xs:annotation>
                                 <xs:complexType>
-                                    <xs:sequence>
-                                        <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                    <xs:choice minOccurs="0" maxOccurs="unbounded">
                                             <xs:element ref="p"/>
                                             <xs:element ref="respStmt"/>
                                         </xs:choice>
-                                    </xs:sequence>
                                     <xs:attributeGroup ref="standard"/>
                                 </xs:complexType>
                             </xs:element>
@@ -231,8 +222,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element name="publisher">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
@@ -300,7 +290,6 @@
                     <xs:group ref="date"/>
                     <xs:element ref="p"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -319,8 +308,7 @@
                 verlegerische Verantwortung </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="name"/>
                     <xs:element name="resp">
                         <xs:annotation>
@@ -350,7 +338,6 @@
                     </xs:element>
                     <xs:group ref="date"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -382,8 +369,7 @@
                             </xs:documentation>
                         </xs:annotation>
                         <xs:complexType mixed="true">
-                            <xs:sequence>
-                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                     <xs:element name="sourceDesc">
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
@@ -396,8 +382,7 @@
                                             </xs:appinfo>
                                         </xs:annotation>
                                         <xs:complexType>
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:element name="sourceDescRegest">
                                                   <xs:annotation>
                                                   <xs:appinfo source="EditVDU">
@@ -474,7 +459,6 @@
                                                   </xs:annotation>
                                                   </xs:element>
                                                 </xs:choice>
-                                            </xs:sequence>
                                         </xs:complexType>
                                     </xs:element>
                                     <xs:element ref="publicationStmt">
@@ -494,7 +478,6 @@
                                         </xs:annotation>
                                     </xs:element>
                                 </xs:choice>
-                            </xs:sequence>
                         </xs:complexType>
                     </xs:element>
                     <xs:choice>
@@ -553,12 +536,10 @@
                                     Texten als Teil eines Corpus z.B. </xs:documentation>
                             </xs:annotation>
                             <xs:complexType>
-                                <xs:sequence>
-                                    <xs:choice maxOccurs="unbounded">
+                                <xs:choice maxOccurs="unbounded">
                                         <xs:element ref="h1"/>
                                         <xs:element ref="text"/>
                                     </xs:choice>
-                                </xs:sequence>
                                 <xs:attributeGroup ref="standard"/>
                             </xs:complexType>
                         </xs:element>
@@ -572,8 +553,7 @@
                                 Register, Verzeichnisse) </xs:documentation>
                         </xs:annotation>
                         <xs:complexType>
-                            <xs:sequence>
-                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                     <xs:element ref="persName">
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
@@ -629,7 +609,6 @@
                                     </xs:element>
                                     <xs:element ref="divNotes"/>
                                 </xs:choice>
-                            </xs:sequence>
                         </xs:complexType>
                     </xs:element>
                 </xs:sequence>
@@ -662,11 +641,7 @@
                 Handschriftensignatur in einer Bibliothek. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:group ref="layout"/>
-                </xs:choice>
-            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
             <xs:attributeGroup ref="standard"/>
             <xs:attribute name="old"/>
         </xs:complexType>
@@ -688,8 +663,7 @@
                 charter</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="class"/>
                     <xs:element ref="abstract"/>
                     <xs:element name="issued" minOccurs="1" maxOccurs="1">
@@ -714,8 +688,7 @@
                                     <xrxe:mixed>false</xrxe:mixed>
                                 </xs:appinfo>
                             </xs:annotation>
-                            <xs:sequence>
-                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                     <xs:element ref="placeName">
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
@@ -743,8 +716,8 @@
                                                   <xrx:example>
                                                   <xrx:i18n>
                                                   <xrx:key>cei_issued_date_example</xrx:key>
-                                                  <xrx:default>&lt;cei:date value="16091001">1609
-                                                  Oktober 1&lt;/cei:date></xrx:default>
+                                                  <xrx:default>&lt;cei:date value="16091001"&gt;1609
+                                                  Oktober 1&lt;/cei:date&gt;</xrx:default>
                                                   </xrx:i18n>
                                                   </xrx:example>
                                                 </xs:documentation>
@@ -760,7 +733,6 @@
                                         </xs:element>
                                     </xs:choice>
                                 </xs:choice>
-                            </xs:sequence>
                             <xs:attributeGroup ref="standard"/>
                         </xs:complexType>
                     </xs:element>
@@ -779,8 +751,7 @@
                             </xs:appinfo>
                         </xs:annotation>
                         <xs:complexType mixed="true">
-                            <xs:sequence>
-                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                     <xs:element ref="traditioForm">
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
@@ -806,7 +777,6 @@
                                     <xs:element ref="p"/>
                                     <!--Erweiterung-->
                                 </xs:choice>
-                            </xs:sequence>
                             <xs:attributeGroup ref="certainty"/>
                             <xs:attribute name="type" type="xs:anySimpleType" use="optional"/>
                             <xs:attribute name="sigil" type="xs:anySimpleType">
@@ -840,8 +810,7 @@
                             </xs:documentation>
                         </xs:annotation>
                         <xs:complexType mixed="true">
-                            <xs:sequence>
-                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                     <xs:element name="listBibl">
                                         <xs:annotation>
                                             <xs:appinfo source="EditVDU">
@@ -858,14 +827,12 @@
                                                 Urkunde betreffen.. </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:choice>
                                                   <xs:element minOccurs="0" ref="ref"/>
                                                   <xs:element ref="bibl"/>
                                                   </xs:choice>
                                                 </xs:choice>
-                                            </xs:sequence>
                                             <xs:attribute name="type"/>
                                             <!--Erweiterung-->
                                             <xs:attributeGroup ref="standard"/>
@@ -887,14 +854,12 @@
                                             </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:choice>
                                                   <xs:element minOccurs="0" ref="ref"/>
                                                   <xs:element ref="bibl"/>
                                                   </xs:choice>
                                                 </xs:choice>
-                                            </xs:sequence>
                                             <xs:attributeGroup ref="standard"/>
                                         </xs:complexType>
                                     </xs:element>
@@ -914,14 +879,12 @@
                                             </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:choice>
                                                   <xs:element minOccurs="0" ref="ref"/>
                                                   <xs:element ref="bibl"/>
                                                   </xs:choice>
                                                 </xs:choice>
-                                            </xs:sequence>
                                             <xs:attributeGroup ref="standard"/>
                                         </xs:complexType>
                                     </xs:element>
@@ -941,14 +904,12 @@
                                                 type="facsimilia" </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:choice>
                                                   <xs:element minOccurs="0" ref="ref"/>
                                                   <xs:element ref="bibl"/>
                                                   </xs:choice>
                                                 </xs:choice>
-                                            </xs:sequence>
                                             <xs:attributeGroup ref="standard"/>
                                         </xs:complexType>
                                     </xs:element>
@@ -968,14 +929,12 @@
                                             </xs:documentation>
                                         </xs:annotation>
                                         <xs:complexType mixed="true">
-                                            <xs:sequence>
-                                                <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                            <xs:choice minOccurs="0" maxOccurs="unbounded">
                                                   <xs:choice>
                                                   <xs:element minOccurs="0" ref="ref"/>
                                                   <xs:element ref="bibl"/>
                                                   </xs:choice>
                                                 </xs:choice>
-                                            </xs:sequence>
                                             <xs:attributeGroup ref="standard"/>
                                         </xs:complexType>
                                     </xs:element>
@@ -992,7 +951,6 @@
                                     <xs:element ref="divNotes"/>
                                     <xs:element ref="incipit"/>
                                 </xs:choice>
-                            </xs:sequence>
                             <xs:attributeGroup ref="standard"/>
                         </xs:complexType>
                     </xs:element>
@@ -1018,7 +976,6 @@
                         </xs:complexType>
                     </xs:element>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1048,25 +1005,23 @@
                 <xrx:example>
                     <xrx:i18n>
                         <xrx:key>cei_abstract_example</xrx:key>
-                        <xrx:default>&lt;cei:abstract>&lt;cei:issuer>Rudolph III. Herzog von
-                            Österreich&lt;/cei:issuer> bestätigt die Privilegien des
-                            &lt;cei:recipient>Klosters Geras&lt;/cei:recipient>, namentlich in
+                        <xrx:default>&lt;cei:abstract&gt;&lt;cei:issuer&gt;Rudolph III. Herzog von
+                            Österreich&lt;/cei:issuer&gt; bestätigt die Privilegien des
+                            &lt;cei:recipient&gt;Klosters Geras&lt;/cei:recipient&gt;, namentlich in
                             gewissen Beziehungen, in denen Beeinträchtigungen eingetreten
-                            waren.&lt;/cei:abstract></xrx:default>
+                            waren.&lt;/cei:abstract&gt;</xrx:default>
                     </xrx:i18n>
                 </xrx:example>
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="class"/>
                     <xs:group ref="Sachliches"/>
                     <xs:group ref="layout"/>
                     <xs:element ref="recipient"/>
                     <xs:element ref="issuer"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1101,12 +1056,10 @@
                         </xs:appinfo>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:group ref="layout"/>
                                 <xs:group ref="biblArch"/>
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1123,12 +1076,10 @@
                         </xs:appinfo>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:element ref="ref"/>
                                 <xs:element ref="bibl"/>
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1147,11 +1098,9 @@
                         </xs:appinfo>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:element ref="desc"/>
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -1262,11 +1211,9 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="witness"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1287,8 +1234,7 @@
             <xs:documentation xml:lang="deu"> Der einzelne Textzeuge </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="traditioForm">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
@@ -1308,7 +1254,6 @@
                     <xs:group ref="layout"/>
                     <xs:group ref="textualElements"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="id"/>
             <xs:attribute name="n" type="xs:anySimpleType">
@@ -1342,11 +1287,7 @@
                 entnehmen oder in der profileDesc zu dokumentieren. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:group ref="layout"/>
-                </xs:choice>
-            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1365,12 +1306,7 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:group ref="layout"/>
-                </xs:choice>
-            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element ref="foreign"/><xs:group ref="layout"/></xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1387,11 +1323,9 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="index"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1413,14 +1347,12 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="notariusDesc"/>
                     <xs:element ref="sealDesc"/>
                     <xs:element ref="subscriptio"/>
                     <xs:element ref="chirograph"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1442,14 +1374,12 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="seal"/>
                     <xs:element ref="legend"/>
                     <xs:group ref="layout"/>
                     <xs:element ref="index"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1476,8 +1406,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="layout"/>
                     <xs:element ref="sigillant"/>
                     <xs:element ref="legend"/>
@@ -1486,7 +1415,6 @@
                     <xs:element ref="sealCondition"/>
                     <xs:element ref="index"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1513,11 +1441,9 @@
                 wieder. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="place"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1544,12 +1470,10 @@
             <xs:documentation xml:lang="deu"> der Siegelinhaber </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="quote"/>
                     <xs:group ref="Sachauszeichnung"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="reg"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1570,8 +1494,7 @@
                 Unterfertigung.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="notariusSub">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
@@ -1593,7 +1516,6 @@
                     <xs:element ref="index"/>
                     <xs:element ref="num"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1645,12 +1567,10 @@
                 preserving archives or the recipient. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attribute name="position" type="xs:anySimpleType" use="optional"/>
             <xs:attributeGroup ref="lang"/>
@@ -1677,12 +1597,10 @@
                 "type" specifies if it refers to specific part of the text.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -1704,14 +1622,12 @@
                 Beschreibstoff (material), Maße (dimensions) etc. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="material"/>
                     <xs:element ref="dimensions"/>
                     <xs:element ref="condition"/>
                     <xs:element ref="decoDesc"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -1731,11 +1647,9 @@
                 Beschreibung</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="p"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="reference"/>
         </xs:complexType>
     </xs:element>
@@ -1755,9 +1669,7 @@
                 Elementen) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:element name="width" type="xs:string">
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element name="width" type="xs:string">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
                                 <xrxe:label>
@@ -1774,8 +1686,7 @@
                                 </xrxe:menu-item>
                             </xs:appinfo>
                         </xs:annotation>
-                    </xs:element>
-                    <xs:element name="height" type="xs:string">
+                    </xs:element><xs:element name="height" type="xs:string">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
                                 <xrxe:label>
@@ -1792,8 +1703,7 @@
                                 </xrxe:menu-item>
                             </xs:appinfo>
                         </xs:annotation>
-                    </xs:element>
-                    <xs:element name="plica" type="xs:string">
+                    </xs:element><xs:element name="plica" type="xs:string">
                         <xs:annotation>
                             <xs:appinfo source="EditVDU">
                                 <xrxe:label>
@@ -1812,9 +1722,7 @@
                             <xs:documentation xml:lang="eng"> describes the depth of the fold used
                                 to secure the threads for the seal </xs:documentation>
                         </xs:annotation>
-                    </xs:element>
-                </xs:choice>
-            </xs:sequence>
+                    </xs:element></xs:choice>
             <xs:attributeGroup ref="standard"/>
             <xs:attribute name="type" type="xs:string"/>
             <!--Erweiterung-->
@@ -1865,12 +1773,7 @@
                 written </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:element ref="foreign"/>
-                    <xs:group ref="layout"/>
-                </xs:choice>
-            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:element ref="foreign"/><xs:group ref="layout"/></xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1922,12 +1825,10 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attribute name="position" type="xs:anySimpleType" use="optional"/>
             <xs:attributeGroup ref="lang"/>
@@ -1956,8 +1857,7 @@
                 Archivale (mit Lagerort, Signatur etc.) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="settlement"/>
                     <xs:element ref="region"/>
                     <xs:element ref="country"/>
@@ -1971,7 +1871,6 @@
                     <xs:element ref="altIdentifier"/>
                     <xs:element ref="hi"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -1990,8 +1889,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:choice>
                         <xs:element ref="settlement"/>
                         <xs:element ref="region"/>
@@ -2005,7 +1903,6 @@
                     <xs:element ref="scope"/>
                     <xs:element ref="note"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
             <xs:attributeGroup ref="type"/>
         </xs:complexType>
@@ -2031,11 +1928,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence minOccurs="0" maxOccurs="unbounded">
-                <xs:choice>
-                    <xs:group ref="layout"/>
-                </xs:choice>
-            </xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded"><xs:group ref="layout"/></xs:choice>
             <xs:attributeGroup ref="expan"/>
             <xs:attributeGroup ref="key"/>
             <xs:attributeGroup ref="lang"/>
@@ -2114,8 +2007,7 @@
                 Signatur/Bezeichnung innerhalb der lagernden Institution. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="settlement"/>
                     <xs:element ref="region"/>
                     <xs:element ref="country"/>
@@ -2124,7 +2016,6 @@
                     <xs:element ref="idno"/>
                     <xs:element ref="scope"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2202,13 +2093,11 @@
                 type="Originaldatierung" </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:element ref="num"/>
                     <xs:element ref="note"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2229,14 +2118,12 @@
                 Transkriptionselemente</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:group ref="Formular"/>
                     <xs:element ref="pTenor"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -2260,8 +2147,7 @@
             <xs:documentation xml:lang="deu">Ein Absatz mit Fließtext </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="archIdentifier"/>
                     <xs:element ref="msIdentifier"/>
@@ -2274,7 +2160,6 @@
                     <xs:element ref="scope"/>
                     <!--Erweiterung-->
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="resp"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2305,15 +2190,13 @@
             <xs:documentation xml:lang="deu">Ein Absatz </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Formular"/>
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="recipient"/>
                     <xs:element ref="issuer"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -2361,13 +2244,11 @@
                 Gottes</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2395,13 +2276,11 @@
                 Titeln</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2428,13 +2307,11 @@
             <xs:documentation xml:lang="deu">Eine Adresse im Urkundentext</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2461,13 +2338,11 @@
             <xs:documentation xml:lang="deu">Die Veröffentlichungsformel</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2495,13 +2370,11 @@
                 Urkunde begründet </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2529,15 +2402,13 @@
                 Ausstellung der Urkunde vorangegangen sind </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="rogatio"/>
                     <xs:element ref="intercessio"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2565,13 +2436,11 @@
                 (cf. VID n. 326 http://www.cei.lmu.de/VID/VID.php?326)</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2599,13 +2468,11 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2633,13 +2500,11 @@
                 Rechtsverfügungen</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2666,13 +2531,11 @@
             <xs:documentation xml:lang="deu">kündigt die Beglaubigungsmittel an</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2700,12 +2563,10 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2733,14 +2594,12 @@
             </xs:appinfo>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element minOccurs="0" maxOccurs="unbounded" ref="setPhrase"/>
                     <xs:element minOccurs="0" maxOccurs="unbounded" ref="notariusSub"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type">
                 <xs:annotation>
                     <xs:documentation xml:lang="deu"> Die Unterscheidung in "Signumzeile",
@@ -2774,13 +2633,11 @@
             <xs:documentation xml:lang="deu">Datierung der Urkunde </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2800,13 +2657,11 @@
                 Floskel</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="setPhrase"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2837,12 +2692,10 @@
                 des "Vocabulaire Internationale de Diplomatique" orientieren. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -2871,12 +2724,10 @@
             <xs:documentation xml:lang="deu">Die Notarsunterschrift </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3002,8 +2853,7 @@
                 machen. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
@@ -3017,7 +2867,6 @@
                     <!--Erweiterung-->
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="extent" type="xs:anySimpleType"/>
             <xs:attribute name="degree" type="xs:anySimpleType">
                 <xs:annotation>
@@ -3071,8 +2920,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
@@ -3080,7 +2928,6 @@
                     <xs:element ref="handShift"/>
                     <xs:element ref="pict"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="extent" type="xs:anySimpleType">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -3195,8 +3042,7 @@
                             Version.</xs:documentation>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:group ref="Sachauszeichnung"/>
                                 <xs:group ref="biblArch"/>
                                 <xs:group ref="layout"/>
@@ -3213,7 +3059,6 @@
                                 <xs:element ref="supplied"/>
                                 <!--Erweiterung-->
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attributeGroup ref="wit"/>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
@@ -3231,8 +3076,7 @@
                         <xs:documentation xml:lang="eng">reading </xs:documentation>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:element ref="w"/>
                                 <!--Erweiterung-->
                                 <xs:element ref="add"/>
@@ -3245,7 +3089,6 @@
                                 <xs:group ref="layout"/>
                                 <xs:group ref="reference"/>
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attribute name="type"/>
                         <!--Erweiterung-->
                         <xs:attributeGroup ref="wit"/>
@@ -3278,8 +3121,7 @@
                 Abkürzung.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
                     <xs:element ref="pb"/>
@@ -3289,7 +3131,6 @@
                     <xs:element ref="sic"/>
                     <xs:element ref="damage"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="abbr">
                 <xs:annotation>
@@ -3323,8 +3164,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
@@ -3333,7 +3173,6 @@
                     <xs:element ref="handShift"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="corr">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -3366,8 +3205,7 @@
                 und dann mit dem Inhalt des Elements korrigiert worden ist. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="sic"/>
                     <xs:element ref="lb"/>
@@ -3378,7 +3216,6 @@
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="sic"/>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
@@ -3407,8 +3244,7 @@
                 ist (z.B. durch Durchstreichen, Unterpunkten, Rasur). </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="add"/>
                     <xs:element ref="supplied"/>
@@ -3419,7 +3255,6 @@
                     <xs:element ref="sic"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3446,8 +3281,7 @@
                 Text ersetzen. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="expan"/>
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
@@ -3462,7 +3296,6 @@
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="status"/>
             <!--Erweiterung-->
             <xs:attributeGroup ref="transcription"/>
@@ -3492,8 +3325,7 @@
                 dokumentiert ist, durch den Editor. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="c"/>
                     <xs:element ref="lb"/>
                     <xs:element ref="pb"/>
@@ -3506,7 +3338,6 @@
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="Referenz"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="transcription"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -3738,13 +3569,11 @@
                 Texte, Texte zwischen Referenzpunkten, Elongata </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:group ref="Formular"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="rend"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -3883,15 +3712,13 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                     <xs:element ref="bibl"/>
                     <xs:element ref="archIdentifier"/>
                     <xs:element ref="msIdentifier"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="place"/>
             <xs:attributeGroup ref="id"/>
             <xs:attributeGroup ref="type"/>
@@ -4006,11 +3833,9 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="textualElements"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4029,11 +3854,9 @@
             <xs:documentation xml:lang="deu">Enthält die Fußnoten zur Urkunde.</xs:documentation>
         </xs:annotation>
         <xs:complexType>
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="note"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -4061,12 +3884,10 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachauszeichnung"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4131,14 +3952,12 @@
                 Urkunde unseres Vaters die folgenden Wortlaut hat: .... </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachauszeichnung"/>
                     <xs:group ref="reference"/>
                     <xs:element ref="foreign"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -4215,12 +4034,10 @@
             <xs:documentation xml:lang="deu">Ein Listenpunkt </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachliches"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
     </xs:element>
@@ -4259,13 +4076,11 @@
                 einer Maßangabe besteht. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="num"/>
                     <xs:element ref="index"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -4292,14 +4107,12 @@
             <xs:documentation xml:lang="deu">Eine Zahlenangabe </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="w"/>
                     <!--Erweiterung-->
                     <xs:element ref="pc"/>
                     <!--Erweiterung-->
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="value"/>
             <xs:attributeGroup ref="lang"/>
@@ -4365,12 +4178,10 @@
                 Stichwörtern (Register, Index) </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="indexName">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -4438,8 +4249,7 @@
                 (=Datumsangabe). </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="num"/>
                     <xs:group ref="Originalbefund"/>
@@ -4447,7 +4257,6 @@
                     <xs:element ref="figure"/>
                     <!-- Erweiterung -->
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="date"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
@@ -4475,13 +4284,11 @@
                 zutreffenden Datums in den Attributen "from" und "to" </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="num"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="from" type="normalizedDateValue" use="required">
                 <xs:annotation>
                     <xs:appinfo source="EditVDU">
@@ -4563,8 +4370,7 @@
             <xs:documentation xml:lang="deu">Die Bezeichnung einer Organisation</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:choice>
                         <xs:annotation>
                             <xs:documentation xml:lang="deu">Geographische Angaben
@@ -4578,7 +4384,6 @@
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="identification"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
@@ -4605,8 +4410,7 @@
             <xs:documentation xml:lang="deu">ein Personenname </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:choice>
                         <xs:annotation>
                             <xs:documentation xml:lang="deu">Geographische Angaben
@@ -4624,7 +4428,6 @@
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="identification"/>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
@@ -4651,13 +4454,11 @@
             <xs:documentation xml:lang="deu">ein Vorname</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4684,8 +4485,7 @@
                 Unterscheidung einer Person z.B. durch Gruppenzuordnung dient.</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="rolename"/>
                     <xs:choice>
                         <xs:annotation>
@@ -4701,7 +4501,6 @@
                     <!--Erweiterung-->
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4728,15 +4527,13 @@
                 ...</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                     <xs:group ref="Sachauszeichnung"/>
                     <!--Erweiterung-->
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="standard"/>
@@ -4766,8 +4563,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="persName"/>
                     <xs:element ref="orgName"/>
@@ -4781,7 +4577,6 @@
                     </xs:choice>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4810,8 +4605,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="persName"/>
                     <xs:element ref="orgName"/>
                     <xs:choice>
@@ -4826,7 +4620,6 @@
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4852,8 +4645,7 @@
             <xs:documentation xml:lang="deu">Ein einzelner Zeuge. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:group ref="Originalbefund"/>
                     <xs:choice>
@@ -4866,7 +4658,6 @@
                     </xs:choice>
                     <xs:element ref="persName"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>
         </xs:complexType>
@@ -4977,8 +4768,7 @@
                 Klöster, Burgen, Bundesländer, Herrschaften, Staaten etc. </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="index"/>
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
@@ -4988,7 +4778,6 @@
                     <!--Erweiterung-->
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="key"/>
             <xs:attributeGroup ref="geog"/>
             <xs:attributeGroup ref="type"/>
@@ -5019,13 +4808,11 @@
             </xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:element ref="foreign"/>
                     <xs:element ref="note"/>
                     <xs:group ref="Originalbefund"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attributeGroup ref="geog"/>
             <xs:attributeGroup ref="type"/>
             <xs:attributeGroup ref="lang"/>
@@ -5086,8 +4873,7 @@
                         </xs:appinfo>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
-                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                                 <xs:element ref="scope"/>
                                 <xs:element name="pubPlace">
                                     <xs:complexType>
@@ -5100,7 +4886,6 @@
                                 </xs:element>
                                 <xs:group ref="date"/>
                             </xs:choice>
-                        </xs:sequence>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>
                 </xs:element>
@@ -5170,15 +4955,13 @@
             <xs:documentation xml:lang="eng">Bibliographic informations</xs:documentation>
         </xs:annotation>
         <xs:complexType mixed="true">
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="layout"/>
                     <xs:element ref="foreign"/>
                     <xs:element ref="quote"/>
                     <xs:group ref="Referenz"/>
                     <xs:group ref="BibliographicInformation"/>
                 </xs:choice>
-            </xs:sequence>
             <xs:attribute name="status"/>
             <!--Erweiterung-->
             <xs:attribute name="type"/>
@@ -5324,9 +5107,7 @@
                             <xrx:default>certainty</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant
-                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"
-                    />
+                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='sic' or $context='del' or $context='expan' or $context='damage'"/>
                 </xs:appinfo>
                 <xs:documentation xml:lang="deu"> Für Genauigkeitsangaben z.B. bei Datierungen,
                     werden mit Schlüsselwörtern (zu benennen in der encodingDesc) oder kurzen
@@ -5362,9 +5143,7 @@
                             <xrx:default>reg</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant
-                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"
-                    />
+                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName'"/>
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>
@@ -5395,9 +5174,7 @@
                             <xrx:default>type</xrx:default>
                         </xrx:i18n>
                     </xrxe:label>
-                    <xrxe:relevant
-                        context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"
-                    />
+                    <xrxe:relevant context="='persName' or $context='orgName' or $context='geogName' or $context='placeName' or $context='c'"/>
                 </xs:appinfo>
             </xs:annotation>
         </xs:attribute>


### PR DESCRIPTION
Schema changes for testing with #944, adding a cei:w-element for words and cei:pc for punctuation, as well as numerous smaller adjustments for attributes and nesting to translate certain features from the TEI charters.