### PR TITLE
Schema extension to allow <cei:note> in <cei:dateRange> for Fontenay charters

### DIFF
--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -4469,6 +4469,7 @@
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element ref="foreign"/>
                 <xs:element ref="num"/>
+                <xs:element ref="note"/>
                 <xs:group ref="Originalbefund"/>
             </xs:choice>
             <xs:attribute name="from" type="normalizedDateValue" use="required">

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -4398,6 +4398,7 @@
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element ref="foreign"/>
                 <xs:element ref="num"/>
+                <xs:element ref="note"/>
                 <xs:group ref="Originalbefund"/>
             </xs:choice>
             <xs:attribute name="from" type="normalizedDateValue" use="required">


### PR DESCRIPTION
Another small schema extension, <cei:note> in <cei:dateRange> - this became necessary due to changes in how some of the dates are translated from the TEI to the CEI. Part of #944.