### PR TITLE
Issue1004 follow-up

### DIFF
--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -684,7 +684,6 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element ref="graphic"/>
                 <xs:element ref="class"/>
                 <xs:element ref="abstract" maxOccurs="1"/>
                 <xs:element name="issued" minOccurs="1" maxOccurs="1">
@@ -2286,7 +2285,6 @@
                 <xs:element ref="figure"/>
                 <xs:element ref="surplus"/>
                 <xs:element name="metamark"/>
-                <xs:element ref="graphic"/>
             </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -670,7 +670,6 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element ref="graphic"/>
                 <xs:element ref="class"/>
                 <xs:element ref="abstract" maxOccurs="1"/>
                 <xs:element name="issued" minOccurs="1" maxOccurs="1">
@@ -2231,7 +2230,6 @@
                 <xs:element ref="figure"/>
                 <xs:element ref="surplus"/>
                 <xs:element name="metamark"/>
-                <xs:element ref="graphic"/>
             </xs:choice>
             <xs:attributeGroup ref="lang"/>
             <xs:attributeGroup ref="standard"/>


### PR DESCRIPTION
cei:graphic as subelement to cei:chDesc and to cei:pTenor is not in use in public data - and semantically not desired, follow-up to #1004 