### PR TITLE
adding siglum of textual witness to charter view

### DIFF
--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -968,7 +968,12 @@
                 <br/>
                 <xsl:if test="./@n !=''">
                     <b>
-                        <xsl:value-of select="concat(./@n, ':')"/>
+                        <xrx:i18n>
+                            <xrx:key>charter-view-witness</xrx:key>
+                            <xrx:default>Textual witness</xrx:default>
+                        </xrx:i18n>
+                        <span>:&#160;</span>
+                        <xsl:value-of select="./@n"/>
                     </b>
                     <br/>
                 </xsl:if>

--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -1203,6 +1203,9 @@
     <xsl:template name="traditioForm">
         <xsl:apply-templates select="./cei:traditioForm"/>
         <br/>
+        <xsl:if test="./@n">
+            <xsl:value-of select="concat(./@n, ':')"/>
+        </xsl:if>
         <xsl:apply-templates select="./child::text()"/>
     </xsl:template>
     <xsl:template match="cei:material">

--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -966,6 +966,12 @@
             </xsl:attribute>
             <div class="witness-text" name="wit">
                 <br/>
+                <xsl:if test="./@n !=''">
+                    <b>
+                        <xsl:value-of select="concat(./@n, ':')"/>
+                    </b>
+                    <br/>
+                </xsl:if>
                 <xsl:call-template name="traditioForm"/>
                 <div class="p">
                     <xsl:if test="./cei:archIdentifier/node()">
@@ -1203,9 +1209,6 @@
     <xsl:template name="traditioForm">
         <xsl:apply-templates select="./cei:traditioForm"/>
         <br/>
-        <xsl:if test="./@n">
-            <xsl:value-of select="concat(./@n, ':')"/>
-        </xsl:if>
         <xsl:apply-templates select="./child::text()"/>
     </xsl:template>
     <xsl:template match="cei:material">


### PR DESCRIPTION
For #1043. Adds a reference to `cei:witness/@n`, if available, to the single charter view as part of the witness-template.