### PR TITLE
schema extension to allow @facs attribute for w, pc, and seg

### DIFF
--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -1232,6 +1232,7 @@
             </xs:choice>
             <xs:attribute name="id"/>
             <xs:attribute name="note"/>
+            <xs:attribute name="facs"/>
         </xs:complexType>
     </xs:element>
     <xs:element name="pc">
@@ -1241,6 +1242,7 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:attribute name="id"/>
+            <xs:attribute name="facs"/>
         </xs:complexType>
     </xs:element>
     <xs:element name="seg">
@@ -1254,6 +1256,7 @@
             <xs:attribute name="type"/>
             <xs:attribute name="id"/>
             <xs:attribute name="part"/>
+            <xs:attribute name="facs"/>
         </xs:complexType>
     </xs:element>
     <xs:element name="head">

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -1176,6 +1176,7 @@
             </xs:choice>
             <xs:attribute name="id"/>
             <xs:attribute name="note"/>
+            <xs:attribute name="facs"/>
         </xs:complexType>
     </xs:element>
     <xs:element name="pc">
@@ -1185,6 +1186,7 @@
         </xs:annotation>
         <xs:complexType mixed="true">
             <xs:attribute name="id"/>
+            <xs:attribute name="facs"/>
         </xs:complexType>
     </xs:element>
     <xs:element name="seg">
@@ -1198,6 +1200,7 @@
             <xs:attribute name="type"/>
             <xs:attribute name="id"/>
             <xs:attribute name="part"/>
+            <xs:attribute name="facs"/>
         </xs:complexType>
     </xs:element>
     <xs:element name="head">


### PR DESCRIPTION
Adds the `@facs` attribute to `cei:w`, `cei:pc`, and `cei:seg` in the schema files, which are needed for annotating the Fontenay collection.