### PR TITLE
More expressive renditions in cei:hi

### DIFF
--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -606,7 +606,7 @@
                         <xsl:when test="contains(., 'sub')">font-size: .83em;vertical-align: sub;</xsl:when>
                         <xsl:when test="contains(., 'smallcaps')">font-variant: small-caps;</xsl:when>
                         <xsl:when test="contains(., 'underline')">text-decoration: underline;</xsl:when>
-                        <xsl:when test="matches(., '^background(-color)?\(.+\)')">
+                        <xsl:when test="matches(., 'background(-color)?\(.+\)')">
                             background-color:<xsl:value-of select="substring-before(substring-after(., '('), ')')"/>;
                         </xsl:when>
                         <xsl:otherwise>background-color:#E6E6E6;</xsl:otherwise>

--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -1213,7 +1213,7 @@
     <xsl:template name="traditioForm">
         <xsl:apply-templates select="./cei:traditioForm"/>
         <br/>
-        <xsl:apply-templates select="./child::text()"/>
+        <xsl:apply-templates select="./child::text()|./cei:hi/text()"/>
     </xsl:template>
     <xsl:template match="cei:material">
         <xsl:if test="./node()">

--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -596,7 +596,7 @@
         </i>
     </xsl:template>
     <xsl:template match="cei:hi">
-        <span>
+        <span title="{@rend}">
             <xsl:attribute name="style">
                 <xsl:for-each select="tokenize(./@rend, '\s+')">
                     <xsl:choose>


### PR DESCRIPTION
BeCoRe users have requested support for more expressive font styles in the HTML, such as "smallcaps", as well as combinations of styles and background colors, such as "italic background(red)", in `cei:hi/@rend` (these are used in the Fontenay collection). The changes here use `span/@style` to combine different styles and background colors. `span/@title` gives additional information (see screenshot), `background-color:#E6E6E6` is retained as fallback for styles not captured by these.

This also includes a change to display the text of `<cei:hi>` in `<cei:witness>`, which has been requested as well.
![Screenshot from 2021-09-01 15-12-48](https://user-images.githubusercontent.com/43009273/131677683-8fdd9498-ba29-4586-89b0-1e3698a1f2b6.png)
