### PR TITLE
authorization for using SKOS app for all registered users

### DIFF
--- a/my/XRX/src/mom/app/skos-editor/widget/skos-editor.widget.xml
+++ b/my/XRX/src/mom/app/skos-editor/widget/skos-editor.widget.xml
@@ -550,7 +550,7 @@
       <xrx:rules>
         <xrx:rule>
           <xrx:user/>
-          <xrx:role>html-author</xrx:role>
+          <xrx:dbgroup>atom</xrx:dbgroup>
         </xrx:rule>
       </xrx:rules>
       <xrx:true>
@@ -573,6 +573,7 @@
             <xrx:key>protected-page-message</xrx:key>
             <xrx:default>Protected page. Please login first.</xrx:default>
           </xrx:i18n>
+          <xrx:subwidget>tag:www.monasterium.net,2011:/mom/widget/login2</xrx:subwidget>
         </div>
       </xrx:false>
     </xrx:auth>


### PR DESCRIPTION
This fix to the SKOS app allows all registered users to access the app. I've also added the login subwidget to the "protected page"-message that appears when a user is not logged in.