### PR TITLE
schema change to allow cei:bibl in cei:witness

### DIFF
--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -1324,6 +1324,7 @@
                     <xs:element ref="msIdentifier"/>
                 </xs:choice>
                 <xs:element ref="auth"/>
+                <xs:element ref="bibl"/>
                 <xs:element ref="physicalDesc"/>
                 <xs:element ref="nota"/>
                 <xs:element ref="rubrum"/>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -1268,6 +1268,7 @@
                     <xs:element ref="msIdentifier"/>
                 </xs:choice>
                 <xs:element ref="auth"/>
+                <xs:element ref="bibl"/>
                 <xs:element ref="physicalDesc"/>
                 <xs:element ref="nota"/>
                 <xs:element ref="rubrum"/>


### PR DESCRIPTION
Addition to the CEI schema files to allow `cei:bibl` as child of `cei:witness`. Closes #1073.