### PR TITLE
CEI schema and cei2html modifications for display of bibliographic data

### DIFF
--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -5099,6 +5099,8 @@
                                     </xs:simpleContent>
                                 </xs:complexType>
                             </xs:element>
+                            <xs:element name="publisher"/>
+                            <xs:element ref="note"/>
                             <xs:group ref="date"/>
                         </xs:choice>
                         <xs:attributeGroup ref="standard"/>

--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -5072,6 +5072,7 @@
                         <xs:simpleContent>
                             <xs:extension base="xs:string">
                                 <xs:attributeGroup ref="standard"/>
+                                <xs:attribute name="type"/>
                             </xs:extension>
                         </xs:simpleContent>
                     </xs:complexType>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -5000,6 +5000,7 @@
                         <xs:simpleContent>
                             <xs:extension base="xs:string">
                                 <xs:attributeGroup ref="standard"/>
+                                <xs:attribute name="type"/>
                             </xs:extension>
                         </xs:simpleContent>
                     </xs:complexType>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -5027,6 +5027,8 @@
                                     </xs:simpleContent>
                                 </xs:complexType>
                             </xs:element>
+                            <xs:element name="publisher"/>
+                            <xs:element ref="note"/>
                             <xs:group ref="date"/>
                         </xs:choice>
                         <xs:attributeGroup ref="standard"/>

--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -995,11 +995,7 @@
                     <xsl:apply-templates select="./cei:auth/cei:notariusDesc"/>
                 </xsl:if>
                 <xsl:apply-templates select="./cei:physicalDesc"/>
-                <ul>
-                    <xsl:for-each select="./cei:bibl">
-                        <xsl:call-template name="bibl"/>
-                    </xsl:for-each>
-                </ul>
+                <xsl:apply-templates select="cei:bibl"/>
                 <ul>
                     <xsl:if test="./cei:nota//text()/normalize-space() != ''">
                         <li>
@@ -1449,7 +1445,7 @@
                     </xrx:i18n>
                 </b>
                 <xsl:text>:&#160;</xsl:text>
-                <xsl:apply-templates select="$cei//cei:note" mode="content"/>
+                <xsl:apply-templates select="$cei//cei:note[not(ancestor::cei:witness)]" mode="content"/>
             </xsl:if>
         </div>
     </xsl:template>
@@ -1457,7 +1453,7 @@
     <xsl:template match="cei:note[not(ancestor::cei:back)]">
         <!-- inline-note: display the reference to a note  -->
         <a id="backlink_{generate-id()}" class="fn-link" href="#{generate-id()}">
-            <xsl:value-of select="count(preceding::cei:note[not(ancestor::cei:back)])+1"/>
+            <xsl:value-of select="count(preceding::cei:note[not(ancestor::cei:back)][not(ancestor::cei:witness)])+1"/>
         </a>
     </xsl:template>
     <xsl:template match="cei:note" priority="-1" mode="content">
@@ -1467,7 +1463,7 @@
                 <xsl:value-of select="generate-id()"/>
             </xsl:attribute>
             <a class="fn-link" href="#backlink_{generate-id()}">
-                <xsl:value-of select="count(preceding::cei:note[not(ancestor::cei:back)])+1"/>
+                <xsl:value-of select="count(preceding::cei:note[not(ancestor::cei:back)][not(ancestor::cei:witness)])+1"/>
             </a>
             <xsl:text/>
             <xsl:apply-templates/>
@@ -1639,6 +1635,12 @@
                 </p>
             </xsl:when>
         </xsl:choose>
+    </xsl:template>
+    <xsl:template match="cei:bibl[parent::cei:witness]">
+        <xsl:apply-templates mode="witness"/>
+    </xsl:template>
+    <xsl:template match="cei:note" mode="witness">
+        <xsl:apply-templates/>
     </xsl:template>
     <xsl:template name="bibl">
         <li>
@@ -2013,6 +2015,12 @@
             <xsl:value-of select="."/>
         </a>
 
+    </xsl:template>
+    
+    <xsl:template match="cei:title">
+        <span title="{@*/local-name()}: {@*}">
+            <xsl:apply-templates/>
+        </span>
     </xsl:template>
 
     <!-- how to cite -->

--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -996,6 +996,11 @@
                 </xsl:if>
                 <xsl:apply-templates select="./cei:physicalDesc"/>
                 <ul>
+                    <xsl:for-each select="./cei:bibl">
+                        <xsl:call-template name="bibl"/>
+                    </xsl:for-each>
+                </ul>
+                <ul>
                     <xsl:if test="./cei:nota//text()/normalize-space() != ''">
                         <li>
                             <b>


### PR DESCRIPTION
This PR changes some aspects of how bibliographical data can be used in CEI and how it is displayed in the charter view on Monasterium. This is needed for importing the bibliographic information used by the Fontenay collection.

This should close the following:
- #1077 
- #1080 
- #1081 