### PR TITLE
reworked display for cei:app in single charter view

### DIFF
--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -783,16 +783,26 @@
     </xsl:template>
     
     <xsl:template match="cei:app">
-        <span class="cei-app" style="background-color:#ffcc99;" title="{cei:rdg}">
+        <span class="cei-app">
             <xsl:attribute name="title">
                 <xsl:apply-templates select="cei:rdg"/>
             </xsl:attribute>
-            <xsl:value-of select="./cei:lem"/>
+            <xsl:attribute name="style">
+                <xsl:choose>
+                    <xsl:when test="count(ancestor::cei:app) mod 2">background-color:#e3e8c9;</xsl:when>
+                    <xsl:otherwise>background-color:#ffd9b3;</xsl:otherwise>
+                </xsl:choose>
+            </xsl:attribute>
+            <xsl:apply-templates select="*[not(self::cei:rdg)]"/>
         </span>
     </xsl:template>
     
     <xsl:template match="cei:rdg">
         <xsl:value-of select="concat('[', ./@wit, ']: ', ., '&#10;')"/>
+    </xsl:template>
+    
+    <xsl:template match="cei:lem">
+        <xsl:apply-templates/>
     </xsl:template>
 
     <xsl:template match="cei:expan">

--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -798,7 +798,10 @@
     </xsl:template>
     
     <xsl:template match="cei:rdg">
-        <xsl:value-of select="concat('[', ./@wit, ']: ', ., '&#10;')"/>
+        <xsl:if test="@wit">
+            <xsl:value-of select="concat('[', ./@wit, ']: ')"/>
+        </xsl:if>
+        <xsl:value-of select="concat(., '&#10;')"/>
     </xsl:template>
     
     <xsl:template match="cei:lem">

--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -781,6 +781,19 @@
             <xsl:apply-templates/>
         </span>
     </xsl:template>
+    
+    <xsl:template match="cei:app">
+        <span class="cei-app" style="background-color:#ffcc99;" title="{cei:rdg}">
+            <xsl:attribute name="title">
+                <xsl:apply-templates select="cei:rdg"/>
+            </xsl:attribute>
+            <xsl:value-of select="./cei:lem"/>
+        </span>
+    </xsl:template>
+    
+    <xsl:template match="cei:rdg">
+        <xsl:value-of select="concat('[', ./@wit, ']: ', ., '&#10;')"/>
+    </xsl:template>
 
     <xsl:template match="cei:expan">
         <xsl:variable name="i18n">


### PR DESCRIPTION
This is a new way to display `cei:app` elements in the single charter view. It marks the apparatus with a colored background, gives the lemma directly in the text and the various readings as a tooltip, including the respective witness, if given (see screenshot). 
It also supports nested `cei:app`s.

This solves #1086.

![Screenshot from 2022-08-30 10-03-56](https://user-images.githubusercontent.com/43009273/187384026-2fc59233-7f50-4ba9-bc34-a39095d0d3b6.png)
