### PR TITLE
several updates for the SKOS editor

### DIFF
--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -702,7 +702,7 @@ ul.namelist {{
                </xrx:i18n>
              </a>
            </li>
-           {if (xmldb:get-current-user() != 'guest') then (
+           {if (xmldb:get-current-user() != 'guest' and $coll = 'controlledVocabulary') then (
            <li>
              <button id="copy-to-user" type="submit">
                <xrx:i18n>

--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -145,10 +145,18 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
                             else($vocabulary//skos:ConceptScheme/skos:prefLabel[1]/text()))
     </xrx:expression>
    </xrx:variable>
-    <xrx:variable>
+   <xrx:variable>
    <xrx:name>$teile</xrx:name>
    <xrx:expression>count($xrx:tokenized-uri)</xrx:expression>
-   </xrx:variable>   
+   </xrx:variable>
+   <xrx:variable>
+   <xrx:name>$file-in-use</xrx:name>
+   <xrx:expression>publication:is-saved($user:db-base-collection/xrx:user, $atomid)</xrx:expression>
+   </xrx:variable>
+   <xrx:variable>
+   <xrx:name>$file-saved-by</xrx:name>
+   <xrx:expression>publication:saved-by-user($user:db-base-collection/xrx:user, $atomid)</xrx:expression>
+   </xrx:variable>
    </xrx:variables>
    
   <xrx:portal>tag:www.monasterium.net,2011:/mom/portal/default</xrx:portal>
@@ -702,16 +710,22 @@ ul.namelist {{
                </xrx:i18n>
              </a>
            </li>
-           {if (xmldb:get-current-user() != 'guest' and $coll = 'controlledVocabulary') then (
-           <li>
-             <button id="copy-to-user" type="submit">
-               <xrx:i18n>
-                 <xrx:key>copy-to-user</xrx:key>
-                 <xrx:default>Create personal copy</xrx:default>
-               </xrx:i18n>
-             </button>
-           </li>
-           )
+           {
+           if (xmldb:get-current-user() != 'guest' and $coll = 'controlledVocabulary') then (
+               if ($file-in-use) then (
+               <span><b>File currently in use by user</b><br/>{$file-saved-by}</span>
+               )
+               else (
+                <li>
+                  <button id="copy-to-user" type="submit">
+                    <xrx:i18n>
+                      <xrx:key>copy-to-user</xrx:key>
+                      <xrx:default>Create personal copy</xrx:default>
+                    </xrx:i18n>
+                  </button>
+                </li>
+              )
+             )
            else ()}
         </ul>
       <div id="msg-suc" style="color:green;display:none">
@@ -730,14 +744,6 @@ ul.namelist {{
           </xrx:i18n>
         </b>
       </div>
-      <div id="msg-fiu" style="color:red;display:none">
-        <b>
-          <xrx:i18n>
-            <xrx:key>file-in-use</xrx:key>
-            <xrx:default>This vocabulary is currently being edited by a user.</xrx:default>
-          </xrx:i18n>
-        </b>
-      </div>
        </div>
         <script type="text/javascript">
           $(document).ready(function(){{
@@ -748,10 +754,6 @@ ul.namelist {{
              			if(response.includes('success')){{
                			$('#msg-suc').css({{opacity: 0, display: "block"}}).animate({{opacity: 1}}, 'slow');
                      $('#msg-suc').delay(5000).fadeOut('slow');
-             			}}
-             			else if(response.includes('file-in-use')){{
-               			$('#msg-fiu').css({{opacity: 0, display: "block"}}).animate({{opacity: 1}}, 'slow');
-                     $('#msg-fiu').delay(5000).fadeOut('slow');
              			}}
              			else{{
              				$('#msg-err').css({{opacity: 0, display: "block"}}).animate({{opacity: 1}}, 'slow');

--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -747,9 +747,11 @@ ul.namelist {{
        </div>
         <script type="text/javascript">
           $(document).ready(function(){{
+            var url = window.location.href;
+            var pageName = url.split('/').pop();
             $("#copy-to-user").click(function(){{
               $.ajax({{
-                url: "/mom/service/my-collection-copy-skos",
+                url: "/mom/service/my-collection-copy-skos?vocab=" + pageName,
                 success: function(response) {{				
              			if(response.includes('success')){{
                			$('#msg-suc').css({{opacity: 0, display: "block"}}).animate({{opacity: 1}}, 'slow');

--- a/my/XRX/src/mom/app/mom/widget/desktop-left-menu.widget.xml
+++ b/my/XRX/src/mom/app/mom/widget/desktop-left-menu.widget.xml
@@ -230,14 +230,6 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
                 </xrx:i18n>
               </a>
             </div>
-            <div class="sub-menu-item">
-              <a href="{ conf:param('request-root') }skos-editor">
-                <xrx:i18n>
-                  <xrx:key>skos-editor</xrx:key>
-                  <xrx:default>SKOS-Editor</xrx:default>
-                </xrx:i18n>
-              </a>
-            </div>
             <h3>
               <xrx:i18n>
                 <xrx:key>image</xrx:key>

--- a/my/XRX/src/mom/app/publication/service/publish-vocabulary.service.xml
+++ b/my/XRX/src/mom/app/publication/service/publish-vocabulary.service.xml
@@ -32,7 +32,11 @@
     <xrx:variables>
         <xrx:variable>
             <xrx:name>$atomid</xrx:name>
-            <xrx:expression>'tag:www.monasterium.net,2011:/controlledVocabulary/IllUrkGlossar'</xrx:expression>
+            <xrx:expression>$data//*:atomid/text()</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
+            <xrx:name>$vocab-name</xrx:name>
+            <xrx:expression>tokenize($atomid, '/')[last()]</xrx:expression>
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$saved-skos</xrx:name>
@@ -52,7 +56,7 @@
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$published-skos</xrx:name>
-            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'public'), 'IllUrkGlossar.xml'))</xrx:expression>
+            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'public'), $vocab-name, '.xml'))</xrx:expression>
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$feed</xrx:name>
@@ -103,6 +107,12 @@
     </xrx:emails>
     <xrx:body>
         {
+        (:
+        let $log := util:log('error', concat('atomid: ', $atomid))
+        let $log := util:log('error', concat('published-skos/base-uri(): ', $published-skos/base-uri()))
+        let $log := util:log('error', concat('saved-skos/base-uri(): ', $saved-skos/base-uri()))
+        :)
+        
         (: move saved vocabulary to public area :)
         let $store-vocab :=
             system:as-user('admin', conf:param('dba-password'), atom:PUTSILENT($feed, util:document-name($published-skos), $saved-skos))

--- a/my/XRX/src/mom/app/publication/widget/saved-vocabularies.widget.xml
+++ b/my/XRX/src/mom/app/publication/widget/saved-vocabularies.widget.xml
@@ -267,6 +267,14 @@ right:220px;
                                             </xrx:i18n>
                                         </a>
                                     </div>-->
+                                    <div data-demoid="go-to-vocab">
+                     		        	<a href="{ conf:param('request-root') }skos-editor?vocab={ skos-edit:get-vocab-filename($vocab) }">
+                     		        		<xrx:i18n>
+                     		        			<xrx:key>open-in-skosedit</xrx:key>
+                     		        			<xrx:default>Open Vocabulary in SKOS-Editor</xrx:default>
+                     		        	  </xrx:i18n>
+                     		        	</a>
+                     		        </div> 
                                     <div data-demoid="ccf5e927-6e78-4b54-9647-f4f03aeef9a0">
                                         <a href="{ conf:param('request-root') }charter-version-difference?id={ $vocab }&amp;backlink=saved-charters">
                                             <xrx:i18n>

--- a/my/XRX/src/mom/app/publication/widget/saved-vocabularies.widget.xml
+++ b/my/XRX/src/mom/app/publication/widget/saved-vocabularies.widget.xml
@@ -173,21 +173,20 @@ right:220px;
 
           let $charter-context := 
             let $probably-collection-id := $tokens[3]
-            let $probably-collection-atom-id := metadata:atomid('collection', $probably-collection-id)
+            let $probably-collection-atom-id := metadata:atomid('controlledVocabulary', $probably-collection-id)
             return
-            if($probably-collection-id = 'IllUrkGlossar') then 'vocab' (: TODO: generalize for all entries in users' vocab directories :)
-            else() 
+            if(exists(metadata:base-collection('controlledVocabulary', 'public')//atom:id[.=$probably-collection-atom-id])) then 'vocab' else 'charter'
           
-          let $vocab-id := $tokens[last()] (: 'IllUrkGlossar' :)
+          let $vocab-id := $tokens[last()]
                   
-          (: get charter from public area :)
-          let $published-vocab := doc(concat(metadata:base-collection-path('controlledVocabulary', 'public'), 'IllUrkGlossar.xml'))
+          (: get vocab from public area :)
+          let $published-vocab := root(metadata:base-collection('controlledVocabulary', 'public')//atom:id[.=$vocab])
           
           (: is charter bookmarked? :)
           let $is-bookmarked := bookmark:is-bookmarked($xrx:user-xml, $vocab)
           
           (: get info for published charter :)
-          let $vocab-name := $published-vocab//atom:entry/atom:content/rdf:RDF/skos:ConceptScheme/skos:prefLabel[1] (: TODO: generalize and make language-dynamic :)
+          let $vocab-name := $published-vocab//atom:content/rdf:RDF/skos:ConceptScheme/skos:prefLabel[1] (: TODO: generalize and make language-dynamic :)
           
           (: status of the charter :)
           let $is-bookmarked := bookmark:is-bookmarked($xrx:user-xml, $vocab)

--- a/my/XRX/src/mom/app/publication/widget/vocabularies-to-publish.widget.xml
+++ b/my/XRX/src/mom/app/publication/widget/vocabularies-to-publish.widget.xml
@@ -149,7 +149,7 @@ right:220px;
   <xrx:view>
   {
 	let $community-member-charters := publication:checkForArchivist($xrx:user-id)
-  let $charters-to-publish := 
+  let $vocabularies-to-publish := 
   (
     for $moderators-user in $user:db-base-collection//xrx:moderator[.=$xrx:user-id]
     return 
@@ -159,7 +159,7 @@ right:220px;
   )
 
     (: pagination :)
-    let $numentries := count($charters-to-publish)
+    let $numentries := count($vocabularies-to-publish)
     let $startstop := pagination:startstop($numentries)
     let $navigation := pagination:navi($numentries)
     
@@ -204,7 +204,7 @@ right:220px;
 	    	</div>
 	      {
 	      
-	      for $id-element at $num in $charters-to-publish
+	      for $id-element at $num in $vocabularies-to-publish
 		    let $releasedate-time := root($id-element)//xrx:saved[xrx:id=$id-element]/xrx:released
 		    let $releaseddate := tokenize($releasedate-time,'T')[1]
 	      let $atom-id := $id-element/text()

--- a/my/XRX/src/mom/app/publication/widget/vocabularies-to-publish.widget.xml
+++ b/my/XRX/src/mom/app/publication/widget/vocabularies-to-publish.widget.xml
@@ -215,10 +215,9 @@ right:220px;
 	
 	      let $entry-is-vocab := 
 	        let $probably-collection-id := $tokens[3]
-	        let $probably-collection-atom-id := metadata:atomid('collection', $probably-collection-id)
-	        return
-	        if($probably-collection-id = 'IllUrkGlossar') then true() (: TODO: generalize for all entries in users' vocab directories :)
-	        else()     
+          let $probably-collection-atom-id := metadata:atomid('controlledVocabulary', $probably-collection-id)
+          return
+          if(exists(metadata:base-collection('controlledVocabulary', 'public')//atom:id[.=$probably-collection-atom-id])) then true() else false()
 	      
 	      (: status of the vocabulary :)
 	      let $is-bookmarked := bookmark:is-bookmarked($xrx:user-xml, $atom-id)

--- a/my/XRX/src/mom/app/skos-editor/service/add-broader.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/add-broader.service.xml
@@ -30,8 +30,12 @@
     </xrx:licence>
     <xrx:variables>
         <xrx:variable>
+            <xrx:name>$vocab-name</xrx:name>
+            <xrx:expression>request:get-parameter("vocab", "")</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
             <xrx:name>$skosfile</xrx:name>
-            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), '/IllUrkGlossar.xml'))</xrx:expression>
+            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), $vocab-name, '.xml'))</xrx:expression>
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$skoscontent</xrx:name>

--- a/my/XRX/src/mom/app/skos-editor/service/add-concept.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/add-concept.service.xml
@@ -30,8 +30,12 @@
     </xrx:licence>
     <xrx:variables>
         <xrx:variable>
+            <xrx:name>$vocab-name</xrx:name>
+            <xrx:expression>request:get-parameter("vocab", "")</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
             <xrx:name>$skosfile</xrx:name>
-            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), '/IllUrkGlossar.xml'))</xrx:expression>
+            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), $vocab-name, '.xml'))</xrx:expression>
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$skoscontent</xrx:name>

--- a/my/XRX/src/mom/app/skos-editor/service/add-preflabel.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/add-preflabel.service.xml
@@ -30,8 +30,12 @@
     </xrx:licence>
     <xrx:variables>
         <xrx:variable>
+            <xrx:name>$vocab-name</xrx:name>
+            <xrx:expression>request:get-parameter("vocab", "")</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
             <xrx:name>$skosfile</xrx:name>
-            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), '/IllUrkGlossar.xml'))</xrx:expression>
+            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), $vocab-name, '.xml'))</xrx:expression>
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$skoscontent</xrx:name>

--- a/my/XRX/src/mom/app/skos-editor/service/edit-definition.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/edit-definition.service.xml
@@ -30,8 +30,12 @@
     </xrx:licence>
     <xrx:variables>
         <xrx:variable>
+            <xrx:name>$vocab-name</xrx:name>
+            <xrx:expression>request:get-parameter("vocab", "")</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
             <xrx:name>$skosfile</xrx:name>
-            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), '/IllUrkGlossar.xml'))</xrx:expression>
+            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), $vocab-name, '.xml'))</xrx:expression>
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$skoscontent</xrx:name>

--- a/my/XRX/src/mom/app/skos-editor/service/my-collection-copy-skos.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/my-collection-copy-skos.service.xml
@@ -81,8 +81,7 @@
             
             (: copy vocab to personal vocab directory and insert xrx:saved-entry into user XML :)
             let $copy-vocab-to-user :=
-                if($file-in-use) then 'file-in-use'
-                else (
+                if(not($file-in-use)) then (
                     let $post := atom:POST(metadata:feed('controlledVocabulary', 'private'), skos-edit:translate-filename($atomid), $public-skos-file)
                             
                     let $saved :=
@@ -96,7 +95,8 @@
                     let $update := update insert $saved into $user-xml//xrx:saved_list
                     (: let $log7 := util:log('error', concat('exists $user-xml?: ', exists($user-xml))) :)
                     return 'success'
-                )
+                    )
+                else ()
             (: let $log8 := util:log('error', concat('$copy-vocab-to-user: ', $copy-vocab-to-user)) :)
             return $copy-vocab-to-user
         )

--- a/my/XRX/src/mom/app/skos-editor/service/my-collection-copy-skos.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/my-collection-copy-skos.service.xml
@@ -34,8 +34,20 @@
             <xrx:expression>concat(conf:param('xrx-user-db-base-uri'), xmldb:encode($xrx:user-id))</xrx:expression>
         </xrx:variable>
         <xrx:variable>
+            <xrx:name>$vocab-name</xrx:name>
+            <xrx:expression>request:get-parameter("vocab", "")</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
+            <xrx:name>$vocab-id</xrx:name>
+            <xrx:expression>concat('tag:www.monasterium.net,2011:/controlledVocabulary/', $vocab-name)</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
+            <xrx:name>$vocab</xrx:name>
+            <xrx:expression>skos-edit:get-vocab-filename($vocab-id)</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
             <xrx:name>$public-skos-file</xrx:name>
-            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'public'), 'IllUrkGlossar.xml'))</xrx:expression>
+            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'public'), $vocab, '.xml'))</xrx:expression>
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$atomid</xrx:name>
@@ -55,6 +67,9 @@
         {
         (:
         let $log1 := util:log('error', concat('$userdir: ', $userdir))
+        let $log5 := util:log('error', concat('$vocab-id: ', $vocab-id))
+        let $log6 := util:log('error', concat('$vocab: ', $vocab))
+        let $log6 := util:log('error', concat('$public-skos-file: ', $public-skos-file))
         let $log2 := util:log('error', concat('exists($public-skos-file): ', exists($public-skos-file)))
         let $log3 := util:log('error', concat('$atomid: ', $atomid))
         let $log4 := util:log('error', concat('$session-username: ', $session-username))

--- a/my/XRX/src/mom/app/skos-editor/service/my-collection-release-skos.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/my-collection-release-skos.service.xml
@@ -70,13 +70,13 @@
                 <to>{ xs:string($moderator) }</to>
                 <cc>{ xs:string($xrx:user-id) }</cc>
                 <bcc></bcc>
-                <subject>MOM-CA - Editorial Service</subject>
+                <subject>MOM-CA Review request: Publication of SKOS file</subject>
                 <message>
                     <text>
                         
-                        MOM-CA - Editorial Service. A modification to the SKOS file has been suggested for publication.
+                        MOM-CA - Editorial Service. A modification to a SKOS file has been suggested for publication.
                         
-                        To moderate the change please login here: { concat($xrx:http-request-root, 'vocabularies-to-publish') }
+                        To review the changes, log into MOM-CA and check your reviewing requests at: { concat($xrx:http-request-root, 'vocabularies-to-publish') }
                         
                         User: { user:firstname-name($xrx:user-id) } ({ $xrx:user-id })
                         <!--Charter: { concat($archid, ' | ', $fondid, $collectionid, ' | ', $charterid) }-->

--- a/my/XRX/src/mom/app/skos-editor/service/my-collection-release-skos.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/my-collection-release-skos.service.xml
@@ -38,8 +38,16 @@
             <xrx:expression>xmldb:get-current-user()</xrx:expression>
         </xrx:variable>
         <xrx:variable>
+            <xrx:name>$vocab-name</xrx:name>
+            <xrx:expression>request:get-parameter("vocab", "")</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
+            <xrx:name>$skosfile</xrx:name>
+            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), $vocab-name, '.xml'))</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
             <xrx:name>$atomid</xrx:name>
-            <xrx:expression>'tag:www.monasterium.net,2011:/controlledVocabulary/IllUrkGlossar'</xrx:expression>
+            <xrx:expression>$skosfile//atom:id/text()</xrx:expression>
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$user-xml</xrx:name>

--- a/my/XRX/src/mom/app/skos-editor/service/my-collection-release-skos.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/my-collection-release-skos.service.xml
@@ -76,7 +76,7 @@
                         
                         MOM-CA - Editorial Service. A modification to the SKOS file has been suggested for publication.
                         
-                        To moderate the change please login here: { concat($xrx:http-request-root, 'charters-to-publish') }
+                        To moderate the change please login here: { concat($xrx:http-request-root, 'vocabularies-to-publish') }
                         
                         User: { user:firstname-name($xrx:user-id) } ({ $xrx:user-id })
                         <!--Charter: { concat($archid, ' | ', $fondid, $collectionid, ' | ', $charterid) }-->

--- a/my/XRX/src/mom/app/skos-editor/service/remove-concept.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/remove-concept.service.xml
@@ -30,8 +30,12 @@
     </xrx:licence>
     <xrx:variables>
         <xrx:variable>
+            <xrx:name>$vocab-name</xrx:name>
+            <xrx:expression>request:get-parameter("vocab", "")</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
             <xrx:name>$skosfile</xrx:name>
-            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), '/IllUrkGlossar.xml'))</xrx:expression>
+            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), $vocab-name, '.xml'))</xrx:expression>
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$skoscontent</xrx:name>

--- a/my/XRX/src/mom/app/skos-editor/service/remove-label.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/remove-label.service.xml
@@ -30,8 +30,12 @@
     </xrx:licence>
     <xrx:variables>
         <xrx:variable>
+            <xrx:name>$vocab-name</xrx:name>
+            <xrx:expression>request:get-parameter("vocab", "")</xrx:expression>
+        </xrx:variable>
+        <xrx:variable>
             <xrx:name>$skosfile</xrx:name>
-            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), '/IllUrkGlossar.xml'))</xrx:expression>
+            <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), $vocab-name, '.xml'))</xrx:expression>
         </xrx:variable>
         <xrx:variable>
             <xrx:name>$skoscontent</xrx:name>

--- a/my/XRX/src/mom/app/skos-editor/skos-edit.xqm
+++ b/my/XRX/src/mom/app/skos-editor/skos-edit.xqm
@@ -26,8 +26,11 @@ module namespace skos-edit = "http://www.monasterium.net/NS/skos-edit";
 
 import module namespace conf = "http://www.monasterium.net/NS/conf"
 at "../xrx/conf.xqm";
+import module namespace metadata = "http://www.monasterium.net/NS/metadata"
+at "../metadata/metadata.xqm";
 
 declare namespace xmldb = "http://exist-db.org/xquery/xmldb";
+declare namespace atom = "http://www.w3.org/2005/Atom";
 
 (: splits up the given atom:id and returns those parts after the atom-tag :)
 declare function skos-edit:object-uri-tokens($atomid as xs:string, $atom-tag-name as xs:string) as xs:string* {
@@ -66,4 +69,15 @@ declare function skos-edit:translate-filename($atomid as xs:string) as xs:string
     let $add-ending := concat($shorten, '.xml')
     return
         xmldb:encode($add-ending)
+};
+
+(: find the name (without extension) of an existing public vocabulary file from its atom:id :)
+declare function skos-edit:get-vocab-filename($atomid as xs:string) as xs:string* {
+    
+    let $vocab-collection := metadata:base-collection('controlledVocabulary', 'public')
+    let $vocab-entry := $vocab-collection//atom:id[. = $atomid]/ancestor::atom:entry
+    let $vocab-uri := base-uri($vocab-entry)
+    let $vocab-name := substring-before(substring-after($vocab-uri, 'metadata.controlledVocabulary.public/'), '.xml')
+    return
+        $vocab-name
 };

--- a/my/XRX/src/mom/app/skos-editor/widget/skos-editor.widget.xml
+++ b/my/XRX/src/mom/app/skos-editor/widget/skos-editor.widget.xml
@@ -550,7 +550,7 @@
       <xrx:rules>
         <xrx:rule>
           <xrx:user/>
-          <xrx:role>html-author</xrx:role>
+          <xrx:dbgroup>atom</xrx:dbgroup>
         </xrx:rule>
       </xrx:rules>
       <xrx:true>
@@ -573,6 +573,7 @@
             <xrx:key>protected-page-message</xrx:key>
             <xrx:default>Protected page. Please login first.</xrx:default>
           </xrx:i18n>
+          <xrx:subwidget>tag:www.monasterium.net,2011:/mom/widget/login2</xrx:subwidget>
         </div>
       </xrx:false>
     </xrx:auth>

--- a/my/XRX/src/mom/app/skos-editor/widget/skos-editor.widget.xml
+++ b/my/XRX/src/mom/app/skos-editor/widget/skos-editor.widget.xml
@@ -26,8 +26,12 @@
     components into other systems, once it leaves the active development stage. </xrx:licence>
   <xrx:variables>
     <xrx:variable>
+      <xrx:name>$vocab</xrx:name>
+      <xrx:expression>request:get-parameter("vocab", "")</xrx:expression>
+    </xrx:variable>
+    <xrx:variable>
       <xrx:name>$skosfile</xrx:name>
-      <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), '/IllUrkGlossar.xml'))</xrx:expression>
+      <xrx:expression>doc(concat(metadata:base-collection-path('controlledVocabulary', 'private'), '/', $vocab, '.xml'))</xrx:expression>
     </xrx:variable>
     <xrx:variable>
       <xrx:name>$skoscontent</xrx:name>
@@ -63,14 +67,6 @@
         <div class="h2">
           <span>SKOS-Editor</span>
         </div>
-      </xrx:view>
-    </xrx:div>
-    <xrx:div>
-      <xrx:key>no-file-div</xrx:key>
-      <xrx:view>
-        <p style="color:red;">
-          <b>There is no glossary file available for this account. Please begin by selecting and copying one from the index search.</b>
-        </p>
       </xrx:view>
     </xrx:div>
     <xrx:div>
@@ -333,7 +329,7 @@
         <script type="text/javascript">
           
         var url = window.location.href;
-        var baseUrl = url.split("?")[0];
+        var baseUrl = url.split("&amp;")[0];
         var urlParams = new URLSearchParams(window.location.search);
         var concept = urlParams. get ('concept');
           
@@ -350,7 +346,7 @@
         
         // adds concept name as query string to base-URL and goes to result
         $('#concept-select').on('change', function () {{
-            var redirectUrl = baseUrl + "?concept=" + $(this).val();
+            var redirectUrl = baseUrl + "&amp;concept=" + $(this).val();
             return (redirectUrl ? window.location = redirectUrl: console.log("Invalid URL!"));
         }});
         
@@ -366,7 +362,7 @@
                 dataType: "text",
                 success: function (data) {{
                     url = $(location).attr("href");
-                    window.location.href = baseUrl + '?concept=' + conceptName;
+                    window.location.href = baseUrl + '&amp;concept=' + conceptName;
                 }}
             }})
         }});
@@ -556,11 +552,6 @@
       <xrx:true>
         <xrx:view>
           <xrx:div>title-div</xrx:div>
-          {
-          if (not(exists($skosfile))) then
-            <xrx:div>no-file-div</xrx:div>
-          else()
-          }
           <xrx:div>select-concept-div</xrx:div>
           <xrx:div>preflabel-div</xrx:div>
           <xrx:div>broader-div</xrx:div>

--- a/my/XRX/src/mom/app/skos-editor/widget/skos-editor.widget.xml
+++ b/my/XRX/src/mom/app/skos-editor/widget/skos-editor.widget.xml
@@ -331,7 +331,8 @@
         var url = window.location.href;
         var baseUrl = url.split("&amp;")[0];
         var urlParams = new URLSearchParams(window.location.search);
-        var concept = urlParams. get ('concept');
+        var concept = urlParams.get('concept');
+        var vocab = urlParams.get('vocab');
           
         // display current concept only if one is selected
         if (concept === null) $('#selected-concept').hide();
@@ -355,7 +356,7 @@
             var conceptName = $('#concept-input').val();
             
             $.ajax({{
-                url: "/mom/service/add-concept",
+                url: "/mom/service/add-concept?vocab=" + vocab,
                 type: "POST",
                 data: conceptName,
                 contentType: "application/xml",
@@ -369,7 +370,7 @@
         
         $('button#delete-concept').click(function () {{
             $.ajax({{
-                url: "/mom/service/remove-concept",
+                url: "/mom/service/remove-concept?vocab=" + vocab,
                 type: "POST",
                 data: concept,
                 contentType: "application/xml",
@@ -418,7 +419,7 @@
             var addLabelUrl = htmlDecode("/mom/service/add-preflabel?concept=" + concept + "&amp;lang=" + labelLang);
             
             $.ajax({{
-                url: addLabelUrl,
+                url: addLabelUrl + "&amp;vocab=" + vocab,
                 type: "POST",
                 data: labelName,
                 contentType: "application/xml",
@@ -436,7 +437,7 @@
             var removeLabelUrl = htmlDecode("/mom/service/remove-label?concept=" + concept + "&amp;lang=" + labelLang);
             
             $.ajax({{
-                url: removeLabelUrl,
+                url: removeLabelUrl + "&amp;vocab=" + vocab,
                 success: function (data) {{
                     //$('#existing-entries-pref').load(location.href + ' #existing-entries-pref');
                     window.location.reload();
@@ -462,7 +463,7 @@
             var addBroaderUrl = htmlDecode("/mom/service/add-broader?concept=" + concept);
             
             $.ajax({{
-                url: addBroaderUrl,
+                url: addBroaderUrl + "&amp;vocab=" + vocab,
                 type: "POST",
                 data: selectBroaderName,
                 contentType: "application/xml",
@@ -480,7 +481,7 @@
             var removeLabelUrl = htmlDecode("/mom/service/remove-label?concept=" + concept + "&amp;broader=" + currentBroaderName);
             
             $.ajax({{
-                url: removeLabelUrl,
+                url: removeLabelUrl + "&amp;vocab=" + vocab,
                 success: function (data) {{
                     //$('#concept-select').load(location.href + ' existing-entries-broader');
                     window.location.reload();
@@ -492,7 +493,7 @@
         
         $('#release-skos').click(function () {{
             $.ajax({{
-                url: "/mom/service/my-collection-release-skos",
+                url: "/mom/service/my-collection-release-skos?vocab=" + vocab,
                 success: function (data) {{
                     $('#release-msg-suc').css({{
                         opacity: 0, display: "block"
@@ -517,9 +518,10 @@
         // submits contents of the textarea to the edit-definition service, reload
         $('button#submit-content').click(function () {{
             var editorContent = CKEDITOR.instances.editor.document.getBody().getHtml();
+            var editDefinitionUrl = "/mom/service/edit-definition?concept=" + concept;
             
             $.ajax({{
-                url: "/mom/service/edit-definition?concept=" + concept,
+                url: editDefinitionUrl + "&amp;vocab=" + vocab,
                 type: "PUT",
                 contentType: "application/xml",
                 data: editorContent,


### PR DESCRIPTION
This adds several features and fixes to the SKOS editor.

- The "create personal copy"-button is now replaced with a notification that the file is in use by another user whenever that is the case.
- The SKOS editor is now accessed from the user's "Saved Vocabularies" page.
- The remaining hardcoded references to the IllUrk glossar have been removed, the editor should now work with all SKOS files.
- Several variable names have been improved and minor cleanup has been done.

This closes the following:
#1071 
#1072 
#1083 