### PR TITLE
removed 5px padding rule for spans in charter.widget (#1092)

### DIFF
--- a/my/XRX/src/mom/app/charter/widget/charter.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/charter.widget.xml
@@ -565,9 +565,6 @@ span.info_i {{
 }}
 
 /* css angaben für search-result aus search app*/
-span {{
-      padding:5px;
-}}
 span.back {{
       margin-left:3em;
 }}


### PR DESCRIPTION
Makes annotated text easier to read, and is requested for the publication of the Fontenay collection.
Closes #1092.