### PR TITLE
show cei:witness/cei:p and enhanced cei:dimensions display in single charter view

### DIFF
--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -1263,7 +1263,7 @@
                             <xrx:key>dimensions</xrx:key>
                             <xrx:default>Dimensions</xrx:default>
                         </xrx:i18n>
-                        <xsl:if test="@*">
+<!--                        <xsl:if test="@*">
                             <xsl:text>&#160;</xsl:text>
                             <xsl:text>(</xsl:text>
                             <xsl:for-each select="@*">
@@ -1272,6 +1272,12 @@
                                     <xsl:text>, </xsl:text>
                                 </xsl:if>
                             </xsl:for-each>
+                            <xsl:text>)</xsl:text>
+                        </xsl:if>
+                        <xsl:text>:&#160;</xsl:text>-->
+                        <xsl:if test="@type">
+                            <xsl:text>&#160;(</xsl:text>
+                            <xsl:value-of select="@type"/>                            
                             <xsl:text>)</xsl:text>
                         </xsl:if>
                         <xsl:text>:&#160;</xsl:text>
@@ -1292,7 +1298,11 @@
                 <xrx:key>height</xrx:key>
                 <xrx:default>height</xrx:default>
             </xrx:i18n>
-            <xsl:text>) </xsl:text>
+        <xsl:if test="parent::cei:dimensions/@unit">
+            <xsl:text>, </xsl:text>
+            <xsl:value-of select="parent::cei:dimensions/@unit"/>
+        </xsl:if>
+        <xsl:text>) </xsl:text>
     </xsl:template>
     <xsl:template match="cei:width">
         <xsl:apply-templates/>
@@ -1301,6 +1311,10 @@
                 <xrx:key>width</xrx:key>
                 <xrx:default>width</xrx:default>
             </xrx:i18n>
+        <xsl:if test="parent::cei:dimensions/@unit">
+            <xsl:text>, </xsl:text>
+            <xsl:value-of select="parent::cei:dimensions/@unit"/>
+        </xsl:if>
             <xsl:text>) </xsl:text>
     </xsl:template>
     <xsl:template match="cei:arch | cei:institution">

--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -1263,6 +1263,17 @@
                             <xrx:key>dimensions</xrx:key>
                             <xrx:default>Dimensions</xrx:default>
                         </xrx:i18n>
+                        <xsl:if test="@*">
+                            <xsl:text>&#160;</xsl:text>
+                            <xsl:text>(</xsl:text>
+                            <xsl:for-each select="@*">
+                                <xsl:value-of select="."/>
+                                <xsl:if test="not(position() = last())">
+                                    <xsl:text>, </xsl:text>
+                                </xsl:if>
+                            </xsl:for-each>
+                            <xsl:text>)</xsl:text>
+                        </xsl:if>
                         <xsl:text>:&#160;</xsl:text>
                     </b>
                     <xsl:apply-templates/>
@@ -1273,6 +1284,24 @@
             </xsl:otherwise>
         </xsl:choose>
         <br/>
+    </xsl:template>
+    <xsl:template match="cei:height">
+        <xsl:apply-templates/>
+        <xsl:text> (</xsl:text>
+            <xrx:i18n>
+                <xrx:key>height</xrx:key>
+                <xrx:default>height</xrx:default>
+            </xrx:i18n>
+            <xsl:text>) </xsl:text>
+    </xsl:template>
+    <xsl:template match="cei:width">
+        <xsl:apply-templates/>
+        <xsl:text> (</xsl:text>
+            <xrx:i18n>
+                <xrx:key>width</xrx:key>
+                <xrx:default>width</xrx:default>
+            </xrx:i18n>
+            <xsl:text>) </xsl:text>
     </xsl:template>
     <xsl:template match="cei:arch | cei:institution">
         <xsl:value-of select="normalize-space(replace(., ',', ''))"/>

--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -1013,6 +1013,7 @@
                                 <span>:&#160;</span>
                             </b>
                         <xsl:apply-templates select="cei:archIdentifier"/>
+                        <xsl:apply-templates select="cei:p"/>
                     </xsl:if>
                 </div>
                 <br/>


### PR DESCRIPTION
Shows paragraph-elements in witness and adds a clearer display of height and width, as well as support for `cei:dimensions/@type` and `cei:dimensions/@unit` attributes, as has been requested for the Fontenay collection.
Closes #1098 and #1099.