### PR TITLE
add notBefore & notAfter attributes to cei:date

### DIFF
--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -5515,6 +5515,8 @@
     <xs:attributeGroup name="date">
         <xs:attributeGroup ref="value"/>
         <xs:attributeGroup ref="certainty"/>
+        <xs:attribute name="notBefore"/>
+        <xs:attribute name="notAfter"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="dateRequired">
         <xs:attributeGroup ref="valueRequired"/>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -5443,6 +5443,8 @@
     <xs:attributeGroup name="date">
         <xs:attributeGroup ref="value"/>
         <xs:attributeGroup ref="certainty"/>
+        <xs:attribute name="notBefore"/>
+        <xs:attribute name="notAfter"/>
     </xs:attributeGroup>
     <xs:attributeGroup name="value">
         <xs:attribute name="value" type="normalizedDateValue" use="required">


### PR DESCRIPTION
This adds the `@notBefore` and `@notAfter` attributes to the `cei:date` element, as discussed in #994.