### PR TITLE
remove extra whitespace from app display

### DIFF
--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -813,7 +813,7 @@
     </xsl:template>
     
     <xsl:template match="cei:rdg">
-        <xsl:apply-templates/>
+        <xsl:apply-templates mode="tooltip"/>
         <xsl:if test="not(node())">
             <xsl:text>om.</xsl:text>
         </xsl:if>
@@ -830,13 +830,17 @@
     </xsl:template>
     
     <xsl:template match="cei:lem" mode="tooltip">
-        <xsl:apply-templates/>
+        <xsl:apply-templates mode="tooltip"/>
         <xsl:if test="@wit">
             <xsl:value-of select="concat(' ', translate(translate(./@wit, ' ', '&#160;'), '#', ''))"/>
         </xsl:if>
         <xsl:text>] </xsl:text>
     </xsl:template>
-
+    
+    <xsl:template match="text()" mode="tooltip">
+        <xsl:value-of select="translate(replace(.,'\s+', ' '), '&#10;&#13;', '')"/>
+    </xsl:template>
+    
     <xsl:template match="cei:expan">
         <xsl:variable name="i18n">
             <xrx:i18n>


### PR DESCRIPTION
A fix to remove the extra whitespace that sometimes appears in `cei:app` in the single charter view.
Closes #1107.