### PR TITLE
normalize space in cei:app tooltips (for #1109)

### DIFF
--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -838,8 +838,8 @@
     </xsl:template>
     
     <xsl:template match="text()" mode="tooltip">
-        <xsl:value-of select="replace(.,'\s+', ' ')"/>
-        <!--removes extra whitespace while preserving leading and trailing space in tooltip text-->
+        <xsl:value-of select="normalize-space(.)"/>
+        <!--normalize whitespace in the cei:app tooltips-->
     </xsl:template>
     
     <xsl:template match="cei:expan">


### PR DESCRIPTION
Changes the `cei:app` tooltips to normalize space as usual.
Closes #1109.