### PR TITLE
allow person index display to get name from descendants of persName

### DIFF
--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -839,7 +839,7 @@ ul.namelist {{
                 let $place := if ($name/following-sibling::tei:occupation/tei:placeName[1]/text()) then $name/following-sibling::tei:occupation/tei:placeName[1]/text() 
                 else()
                 let $aufbereitung := if($place) then substring-before(serialize($place), ' ') else(concat(' (', substring-after($personid, 'P_'), ')'))
-                let $inhalt := concat($name/text(), ' ',$aufbereitung)
+                let $inhalt := concat(string-join($name//text()), ' ',$aufbereitung)
                 let $memo := if($personid != "") then session:set-attribute($personid, $inhalt) else ()
                 for $n in  $name                
                 return                                      


### PR DESCRIPTION
Allows list of names in person index view to be created from all descendant text nodes of `tei:persName`.
This closes #1120.