### PR TITLE
allow placeName in date

### DIFF
--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -4430,6 +4430,7 @@
             <xs:element ref="ref"/>
             <xs:element ref="figure"/>
             <xs:element ref="note"/>
+            <xs:element ref="placeName"/>
         </xs:choice>
         <xs:attributeGroup ref="lang"/>
         <xs:attributeGroup ref="standard"/>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -4370,6 +4370,7 @@
                 <xs:element ref="ref"/>
                 <xs:element ref="figure"/>
                 <xs:element ref="note"/>
+                <xs:element ref="placeName"/>
             </xs:choice>
             <xs:attributeGroup ref="date"/>
             <xs:attributeGroup ref="lang"/>


### PR DESCRIPTION
Allows `cei:placeName` in `cei:date` in the CEI schema.
This closes #1137.