### PR TITLE
order index names by persName instead of xml-id (#1143)

### DIFF
--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -823,7 +823,7 @@ ul.namelist {{
               return
               if ($parameter != '') then
               let $personenliste := $index:personcollection/atom:entry[contains(atom:id, $voc)]//tei:text
-              let $eintrag := if($parameter != '' and $parameter != 'A-Z') then $personenliste//tei:person[starts-with(substring-after(@xml:id, 'P_'), $parameter)] 
+              let $eintrag := if($parameter != '' and $parameter != 'A-Z') then $personenliste//tei:person[starts-with(tei:persName[1], $parameter)] 
                               else if($parameter = 'A-Z') then $personenliste//tei:person
                               else()
 
@@ -833,7 +833,7 @@ ul.namelist {{
                (: das trifft dann zu, wenn ein Buchstabe keine Namenseinträge hat:)
                 else(
                 for $person in $eintrag
-                order by $person/tei:persName
+                order by $person/tei:persName[1]/normalize-space()
                 return
                 let $personid := data($person/@xml:id)
                 let $name := $person/tei:persName (: [starts-with(., $parameter)] :)


### PR DESCRIPTION
Use the (first) `persName` of a person instead of the `xml:id` for ordering the list of names in the person index.

Closes #1143.