### PR TITLE
Add EDM to OAI-PMH; add License to CEI

### DIFF
--- a/my/XRX/src/core/app/oaiinterface/oaiinterface.xqm
+++ b/my/XRX/src/core/app/oaiinterface/oaiinterface.xqm
@@ -433,19 +433,18 @@ declare function local:prepareCache($name as xs:string, $oai-collections as xs:s
 (: Param $oai-collection as specific path to recources in DB/ Param $base-url as baseURL of the OAI- Interface:)
 declare function oaiinterface:main($oai-collections as xs:string*, $base-url as xs:string, $function-pointer  ){
     (: OAI- PMH informations - have to be defined:)
-    <OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" 
+    <oai:OAI-PMH xmlns:oai="http://www.openarchives.org/OAI/2.0/" 
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
-         http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-    <responseDate>{current-dateTime()}</responseDate>
-    <request> {(for $parameter in $oaiinterface:parameters
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+    <oai:responseDate>{current-dateTime()}</oai:responseDate>
+    <oai:request> {(for $parameter in $oaiinterface:parameters
                 return
                     attribute {$parameter}{request:get-parameter(string($parameter),0)})
-                ,$base-url}</request>
+                ,$base-url}</oai:request>
     {
     (: check parameters and produce a response:)
     local:validate-params($oai-collections, $base-url, $function-pointer)
     }
-     </OAI-PMH>
+     </oai:OAI-PMH>
 };
 

--- a/my/XRX/src/core/app/oaiinterface/oaiinterface.xqm
+++ b/my/XRX/src/core/app/oaiinterface/oaiinterface.xqm
@@ -80,6 +80,11 @@ declare variable $oaiinterface:metadata-formats :=
                     <oai:schema>http://www.europeana.eu/schemas/ese/ESE-V3.2.xsd</oai:schema>
                     <oai:metadataNamespace>http://www.europeana.eu/schemas/ese/</oai:metadataNamespace>
                 </oai:metadataFormat>
+                <oai:metadataFormat>
+                    <oai:metadataPrefix>edm</oai:metadataPrefix>
+                    <oai:schema>https://www.europeana.eu/schemas/edm/EDM.xsd</oai:schema>
+                    <oai:metadataNamespace>http://www.europeana.eu/schemas/edm/</oai:metadataNamespace>
+                </oai:metadataFormat>
             </oai:ListMetadataFormats>;
 (: Tag of the document to compare the from/until parameters :)            
 declare variable $oaiinterface:tag-to-compare-date := "atom:updated";

--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -5812,7 +5812,7 @@
     <!-- Non-empty text restriction -->
     <xs:simpleType name="NonEmptyText">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\S+"/>
+            <xs:minLength value="1"/>
         </xs:restriction>
     </xs:simpleType>
     <!-- Definition of LicenseType with enumeration of allowed URLs -->

--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -286,7 +286,7 @@
                             Einschränkungen ("restricted") </xs:documentation>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                             <xs:element ref="p" minOccurs="0"/>
                             <xs:element name="license" minOccurs="0">
                                 <xs:annotation>
@@ -315,7 +315,7 @@
                                     </xs:simpleContent>
                                 </xs:complexType>
                             </xs:element>
-                        </xs:sequence>
+                        </xs:choice>
                         <xs:attribute name="status" type="xs:anySimpleType"/>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>

--- a/my/XRX/src/mom/app/cei/xsd/cei.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei.xsd
@@ -288,6 +288,33 @@
                     <xs:complexType mixed="true">
                         <xs:sequence>
                             <xs:element ref="p" minOccurs="0"/>
+                            <xs:element name="license" minOccurs="0">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_license</xrx:key>
+                                                <xrx:default>license</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:relevant>false</xrxe:relevant>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> Lizenzinformationen: Das Attribut @target enthält die URI der ausgewählten Lizenz. Der Elementtext bietet ergänzende Informationen, wie die korrekte Zuschreibung und relevante Anmerkungen. </xs:documentation>
+                                    <xs:documentation xml:lang="eng"> License Information: The @target attribute includes the URI of the selected license. The text of the element provides additional information, such as the correct attribution and relevant notes. </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:simpleContent>
+                                        <xs:extension base="NonEmptyText">
+                                            <xs:attribute name="target" type="LicenseType" use="required">
+                                                <xs:annotation>
+                                                    <xs:documentation xml:lang="eng">The URI of the selected license.</xs:documentation>
+                                                    <xs:documentation xml:lang="deu">Die URI der ausgewählten Lizenz.</xs:documentation>
+                                                </xs:annotation>
+                                            </xs:attribute>
+                                        </xs:extension>
+                                    </xs:simpleContent>
+                                </xs:complexType>
+                            </xs:element>
                         </xs:sequence>
                         <xs:attribute name="status" type="xs:anySimpleType"/>
                         <xs:attributeGroup ref="standard"/>
@@ -5780,6 +5807,38 @@
     <xs:simpleType name="idnoValue">
         <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- Non-empty text restriction -->
+    <xs:simpleType name="NonEmptyText">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\S+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- Definition of LicenseType with enumeration of allowed URLs -->
+    <xs:simpleType name="LicenseType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">LicenseType is a simple type which restricts the allowed values to a set of URLs. The URLs are taken from the following sources: <a href="https://europeana.atlassian.net/wiki/spaces/EF/pages/1503756289/Providing+copyright+metadata+to+Europeana#Available-values">Europeana documentation</a>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:anyURI">
+            <!-- Creative Commons Licenses -->
+            <xs:enumeration value="http://creativecommons.org/licenses/by/4.0/"/>
+            <xs:enumeration value="http://creativecommons.org/licenses/by-sa/4.0/"/>
+            <xs:enumeration value="http://creativecommons.org/licenses/by-nd/4.0/"/>
+            <xs:enumeration value="http://creativecommons.org/licenses/by-nc/4.0/"/>
+            <xs:enumeration value="http://creativecommons.org/licenses/by-nc-sa/4.0/"/>
+            <xs:enumeration value="http://creativecommons.org/licenses/by-nc-nd/4.0/"/>
+            <!-- Rights Statements -->
+            <xs:enumeration value="http://rightsstatements.org/vocab/NoC-NC/1.0/"/>
+            <xs:enumeration value="http://rightsstatements.org/vocab/NoC-OKLR/1.0/"/>
+            <xs:enumeration value="http://rightsstatements.org/vocab/InC/1.0/"/>
+            <xs:enumeration value="http://rightsstatements.org/vocab/InC-EDU/1.0/"/>
+            <xs:enumeration value="http://rightsstatements.org/vocab/InC-EU-OW/1.0/"/>
+            <xs:enumeration value="http://rightsstatements.org/vocab/CNE/1.0/"/>
+            <!-- Public Domain Tools -->
+            <xs:enumeration value="http://creativecommons.org/publicdomain/mark/1.0/"/>
+            <xs:enumeration value="http://creativecommons.org/publicdomain/zero/1.0/"/>
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -286,6 +286,33 @@
                     <xs:complexType mixed="true">
                         <xs:sequence>
                             <xs:element ref="p" minOccurs="0"/>
+                            <xs:element name="license" minOccurs="0">
+                                <xs:annotation>
+                                    <xs:appinfo source="EditVDU">
+                                        <xrxe:label>
+                                            <xrx:i18n>
+                                                <xrx:key>cei_license</xrx:key>
+                                                <xrx:default>license</xrx:default>
+                                            </xrx:i18n>
+                                        </xrxe:label>
+                                        <xrxe:relevant>false</xrxe:relevant>
+                                    </xs:appinfo>
+                                    <xs:documentation xml:lang="deu"> Lizenzinformationen: Das Attribut @target enthält die URI der ausgewählten Lizenz. Der Elementtext bietet ergänzende Informationen, wie die korrekte Zuschreibung und relevante Anmerkungen. </xs:documentation>
+                                    <xs:documentation xml:lang="eng"> License Information: The @target attribute includes the URI of the selected license. The text of the element provides additional information, such as the correct attribution and relevant notes. </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:simpleContent>
+                                        <xs:extension base="NonEmptyText">
+                                            <xs:attribute name="target" type="LicenseType" use="required">
+                                                <xs:annotation>
+                                                    <xs:documentation xml:lang="eng">The URI of the selected license.</xs:documentation>
+                                                    <xs:documentation xml:lang="deu">Die URI der ausgewählten Lizenz.</xs:documentation>
+                                                </xs:annotation>
+                                            </xs:attribute>
+                                        </xs:extension>
+                                    </xs:simpleContent>
+                                </xs:complexType>
+                            </xs:element>
                         </xs:sequence>
                         <xs:attribute name="status" type="xs:anySimpleType"/>
                         <xs:attributeGroup ref="standard"/>
@@ -5674,6 +5701,38 @@
     <xs:simpleType name="idnoValue">
         <xs:restriction base="xs:string">
             <xs:minLength value="1"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- Non-empty text restriction -->
+    <xs:simpleType name="NonEmptyText">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\S+"/>
+        </xs:restriction>
+    </xs:simpleType>
+    <!-- Definition of LicenseType with enumeration of allowed URLs -->
+    <xs:simpleType name="LicenseType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">LicenseType is a simple type which restricts the allowed values to a set of URLs. The URLs are taken from the following sources: <a href="https://europeana.atlassian.net/wiki/spaces/EF/pages/1503756289/Providing+copyright+metadata+to+Europeana#Available-values">Europeana documentation</a>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:anyURI">
+            <!-- Creative Commons Licenses -->
+            <xs:enumeration value="http://creativecommons.org/licenses/by/4.0/"/>
+            <xs:enumeration value="http://creativecommons.org/licenses/by-sa/4.0/"/>
+            <xs:enumeration value="http://creativecommons.org/licenses/by-nd/4.0/"/>
+            <xs:enumeration value="http://creativecommons.org/licenses/by-nc/4.0/"/>
+            <xs:enumeration value="http://creativecommons.org/licenses/by-nc-sa/4.0/"/>
+            <xs:enumeration value="http://creativecommons.org/licenses/by-nc-nd/4.0/"/>
+            <!-- Rights Statements -->
+            <xs:enumeration value="http://rightsstatements.org/vocab/NoC-NC/1.0/"/>
+            <xs:enumeration value="http://rightsstatements.org/vocab/NoC-OKLR/1.0/"/>
+            <xs:enumeration value="http://rightsstatements.org/vocab/InC/1.0/"/>
+            <xs:enumeration value="http://rightsstatements.org/vocab/InC-EDU/1.0/"/>
+            <xs:enumeration value="http://rightsstatements.org/vocab/InC-EU-OW/1.0/"/>
+            <xs:enumeration value="http://rightsstatements.org/vocab/CNE/1.0/"/>
+            <!-- Public Domain Tools -->
+            <xs:enumeration value="http://creativecommons.org/publicdomain/mark/1.0/"/>
+            <xs:enumeration value="http://creativecommons.org/publicdomain/zero/1.0/"/>
         </xs:restriction>
     </xs:simpleType>
 </xs:schema>

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -5706,7 +5706,7 @@
     <!-- Non-empty text restriction -->
     <xs:simpleType name="NonEmptyText">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\S+"/>
+            <xs:minLength value="1"/>
         </xs:restriction>
     </xs:simpleType>
     <!-- Definition of LicenseType with enumeration of allowed URLs -->

--- a/my/XRX/src/mom/app/cei/xsd/cei10.xsd
+++ b/my/XRX/src/mom/app/cei/xsd/cei10.xsd
@@ -284,7 +284,7 @@
                             Einschränkungen ("restricted") </xs:documentation>
                     </xs:annotation>
                     <xs:complexType mixed="true">
-                        <xs:sequence>
+                        <xs:choice minOccurs="0" maxOccurs="unbounded">
                             <xs:element ref="p" minOccurs="0"/>
                             <xs:element name="license" minOccurs="0">
                                 <xs:annotation>
@@ -313,7 +313,7 @@
                                     </xs:simpleContent>
                                 </xs:complexType>
                             </xs:element>
-                        </xs:sequence>
+                        </xs:choice>
                         <xs:attribute name="status" type="xs:anySimpleType"/>
                         <xs:attributeGroup ref="standard"/>
                     </xs:complexType>

--- a/my/XRX/src/mom/app/mom/mom.app.xml
+++ b/my/XRX/src/mom/app/mom/mom.app.xml
@@ -197,6 +197,11 @@
       <xrx:name>cei2ese.xsl</xrx:name>
     </xrx:resource>
     <xrx:resource>
+      <xrx:atomid>tag:www.monasterium.net,2011:/mom/resource/xsl/cei2edm</xrx:atomid>
+      <xrx:relativepath>xsl/</xrx:relativepath>
+      <xrx:name>cei2edm.xsl</xrx:name>
+    </xrx:resource>
+    <xrx:resource>
       <xrx:atomid>tag:www.monasterium.net,2011:/mom/resource/xsl/cei2oaidc</xrx:atomid>
       <xrx:relativepath>xsl/</xrx:relativepath>
       <xrx:name>cei2oaidc.xsl</xrx:name>

--- a/my/XRX/src/mom/app/mom/platform-oai.xqm
+++ b/my/XRX/src/mom/app/mom/platform-oai.xqm
@@ -367,17 +367,16 @@ declare function platform-oai:create-file($object-id as xs:string, $context as x
 declare function platform-oai:error-message($base-url as xs:string) {
     let $message :=
                 (: OAI- PMH informations - have to be defined:)
-                <OAI_PMH xmlns="http://www.openarchives.org/OAI/2.0/" 
+                <oai:OAI_PMH xmlns:oai="http://www.openarchives.org/OAI/2.0/" 
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/
-                     http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
-                <responseDate>{current-dateTime()}</responseDate>
-                <request> {(for $parameter in request:get-parameter-names()
+                     xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+                <oai:responseDate>{current-dateTime()}</oai:responseDate>
+                <oai:request> {(for $parameter in request:get-parameter-names()
                             return
                                 attribute {$parameter}{request:get-parameter(string($parameter),0)})
-                            ,$base-url}</request>
-                 <error code="noRecordsMatch">Base- URL has not been released yet! Please check your URL or contact the metadata manager of the archive!</error>
-                 </OAI_PMH> 
+                            ,$base-url}</oai:request>
+                 <oai:error code="noRecordsMatch">Base- URL has not been released yet! Please check your URL or contact the metadata manager of the archive!</oai:error>
+                 </oai:OAI_PMH> 
         return
             $message
 };

--- a/my/XRX/src/mom/app/mom/platform-oai.xqm
+++ b/my/XRX/src/mom/app/mom/platform-oai.xqm
@@ -31,6 +31,8 @@ declare function platform-oai:transform($verb as xs:string, $document as node()*
                             collection($platform-oai:platform-base-uri)//xsl:stylesheet[@id ='cei2oaidc']
                         else if(fn:compare($metadata-prefix,"ese")=0)then
                             collection($platform-oai:platform-base-uri)//xsl:stylesheet[@id ='cei2ese']
+                        else if(fn:compare($metadata-prefix,"edm")=0)then
+                            collection($platform-oai:platform-base-uri)//xsl:stylesheet[@id ='cei2edm']
                         else collection($platform-oai:platform-base-uri)//xsl:stylesheet[@id ='cei2oaidc']
     (: XSLT for header transformation :)
     let $header-xsl := collection($platform-oai:platform-base-uri)//xsl:stylesheet[@id ='cei2oaiheader']

--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -22,14 +22,17 @@
       <xsl:variable name="cei-decoDesc" select="normalize-space(.//cei:decoDesc)" />
       <xsl:if test="$cei-abstract or $cei-decoDesc">
         <dc:description>
-          <xsl:if test="$cei-decoDesc">
-            <xsl:text>Abstract: </xsl:text>
-          </xsl:if>
           <xsl:if test="$cei-abstract">
+            <xsl:if test="$cei-decoDesc">
+              <xsl:text>Abstract: </xsl:text>
+            </xsl:if>
             <xsl:value-of select="$cei-abstract" />
           </xsl:if>
           <xsl:if test="$cei-decoDesc">
-            <xsl:text>; Art-historical description: </xsl:text>
+            <xsl:if test="$cei-abstract">
+              <xsl:text> — </xsl:text>
+            </xsl:if>
+            <xsl:text>Art-historical description: </xsl:text>
             <xsl:value-of select="$cei-decoDesc" />
           </xsl:if>
         </dc:description>

--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -59,8 +59,6 @@
             <xsl:value-of select="concat('Charter: ', $fond-id, ' ', .//cei:idno/@id)" />
           </dc:title>
           <!-- Types -->
-          <dc:type rdf:resource="http://purl.org/dc/dcmitype/PhysicalObject" />
-          <dc:type rdf:resource="http://purl.org/dc/dcmitype/Text" />
           <dc:type>Charter</dc:type>
           <edm:type>TEXT</edm:type>
           <!-- Identifier -->

--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -3,6 +3,7 @@
   <xsl:param name="data-provider" />
   <xsl:param name="base-image-url" />
   <xsl:param name="fond-id" />
+  <xsl:param name="opt-collection-title" />
   <xsl:template match="/">
     <!-- Create the ids that the elements will use -->
     <xsl:variable name="provided-cho-id" select="concat('#', .//atom:id)" />
@@ -28,15 +29,19 @@
             <xsl:value-of select="$license-text" />
           </dc:rights>
         </xsl:when>
-        <xsl:when test="$archive">
-          <edm:rights rdf:resource="http://creativecommons.org/licenses/by-nc/4.0/" />
-          <dc:rights>
-            <xsl:value-of select="$archive" />
-          </dc:rights>
-        </xsl:when>
         <xsl:otherwise>
           <edm:rights rdf:resource="http://creativecommons.org/licenses/by-nc/4.0/" />
-          <dc:rights>Monasterium.net</dc:rights>
+          <dc:rights>
+            <xsl:choose>
+              <xsl:when test="$opt-collection-title">
+                <xsl:value-of select="$opt-collection-title" />
+              </xsl:when>
+              <xsl:when test="$archive">
+                <xsl:value-of select="$archive" />
+              </xsl:when>
+              <xsl:otherwise><xsl:text>Monasterium.net</xsl:text></xsl:otherwise>
+            </xsl:choose>
+          </dc:rights>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:variable>

--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -1,0 +1,204 @@
+<xsl:stylesheet id="cei2edm" version="1.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:cei="http://www.monasterium.net/NS/cei" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:ese="http://www.europeana.eu/schemas/ese/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:ore="http://www.openarchives.org/ore/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svcs="http://rdfs.org/sioc/services#" xmlns:xrx="http://www.mom-ca.uni-koeln.de/NS/xrx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform https://www.w3.org/2007/schema-for-xslt20.xsd">
+  <xsl:param name="platform-id" />
+  <xsl:param name="data-provider" />
+  <xsl:param name="base-image-url" />
+  <xsl:param name="fond-id" />
+  <xsl:template match="/">
+    <!-- Create the ids that the elements will use -->
+    <xsl:variable name="provided-cho-id" select="concat('#', .//atom:id)" />
+    <xsl:variable name="aggregation-id">
+      <xsl:text>https://www.monasterium.net/mom/</xsl:text>
+      <xsl:value-of select="substring-after(.//atom:id, 'charter/')" />
+      <xsl:text>/charter</xsl:text>
+    </xsl:variable>
+    <xsl:variable name="image-ids">
+      <xsl:for-each select="//cei:graphic">
+        <id base="{concat($base-image-url, @url)}" iiif="{concat($base-image-url, @url, '/full/512,/0/default.jpg')}" />
+      </xsl:for-each>
+    </xsl:variable>
+    <!-- Start OAI output -->
+    <oai:metadata>
+      <rdf:RDF>
+        <!-- Aggregation -->
+        <ore:Aggregation rdf:about="{$aggregation-id}">
+          <!-- Connected CHO -->
+          <edm:aggregatedCHO rdf:resource="{$provided-cho-id}" />
+          <!-- Connected WebResources -->
+          <xsl:for-each select="$image-ids/id">
+            <edm:isShownBy rdf:resource="{@iiif}" />
+          </xsl:for-each>
+          <!-- License -->
+          <edm:rights rdf:resource="https://creativecommons.org/licenses/by-nc/3.0/" />
+          <!-- Data provider -->
+          <edm:dataProvider>Monasterium.net</edm:dataProvider>
+        </ore:Aggregation>
+        <!-- Image related elements -->
+        <xsl:for-each select="$image-ids/id">
+          <!-- Image webresource -->
+          <edm:WebResource rdf:about="{@iiif}">
+            <svcs:has_service rdf:resource="{@base}" />
+          </edm:WebResource>
+          <!-- Service for IIIF-->
+          <svcs:Service rdf:about="{@base}">
+            <dcterms:conformsTo rdf:resource="http://iiif.io/api/image" />
+          </svcs:Service>
+        </xsl:for-each>
+        <!-- CHO -->
+        <edm:ProvidedCHO rdf:about="{$provided-cho-id}">
+          <!-- Title -->
+          <dc:title>
+            <xsl:value-of select="concat('Charter: ', $fond-id, ' ', .//cei:idno/@id)" />
+          </dc:title>
+          <!-- Types -->
+          <dc:type rdf:resource="http://purl.org/dc/dcmitype/PhysicalObject" />
+          <dc:type rdf:resource="http://purl.org/dc/dcmitype/Text" />
+          <dc:type>Charter</dc:type>
+          <edm:type>TEXT</edm:type>
+          <!-- Identifier -->
+          <dc:identifier>
+            <xsl:value-of select=".//cei:idno" />
+          </dc:identifier>
+          <!-- Abstract -->
+          <xsl:if test=".//cei:abstract/text()">
+            <dc:description>
+              <xsl:value-of select="normalize-space(.//cei:abstract)" />
+            </dc:description>
+          </xsl:if>
+          <!-- Language -->
+          <xsl:if test=".//cei:lang_MOM/text()">
+            <dc:language>
+              <xsl:value-of select=".//cei:lang_MOM" />
+            </dc:language>
+          </xsl:if>
+          <!-- Dimensions -->
+          <xsl:if test=".//cei:physicalDesc/cei:dimensions/text()">
+            <dcterms:extent>
+              <xsl:value-of select=".//cei:physicalDesc/cei:dimensions" />
+            </dcterms:extent>
+          </xsl:if>
+          <!-- Material -->
+          <xsl:if test=".//cei:material/text()">
+            <dcterms:medium>
+              <xsl:value-of select=".//cei:material" />
+            </dcterms:medium>
+          </xsl:if>
+          <!-- Issuer -->
+          <xsl:if test=".//cei:issuer/text()">
+            <dc:creator>
+              <xsl:value-of select=".//cei:issuer" />
+            </dc:creator>
+          </xsl:if>
+          <!-- Notarius -->
+          <xsl:if test=".//cei:notariusSub/text()">
+            <dc:creator>
+              <xsl:value-of select=".//cei:notariusSub" />
+            </dc:creator>
+          </xsl:if>
+          <!-- Associated place names -->
+          <xsl:if test=".//cei:placeName/text()">
+            <xsl:for-each select=".//cei:abstract/cei:placeName">
+              <dc:spatial>
+                <xsl:value-of select="./text()" />
+              </dc:spatial>
+            </xsl:for-each>
+          </xsl:if>
+          <!-- Associated geography names -->
+          <xsl:if test=".//cei:geogName/text()">
+            <xsl:for-each select=".//cei:geogName">
+              <dc:spatial>
+                <xsl:value-of select="./text()" />
+              </dc:spatial>
+            </xsl:for-each>
+          </xsl:if>
+          <!-- Keywords -->
+          <xsl:if test=".//cei:keyword">
+            <xsl:for-each select=".//cei:keyword">
+              <dc:subject>
+                <xsl:value-of select="./text()" />
+              </dc:subject>
+            </xsl:for-each>
+          </xsl:if>
+          <!-- Date -->
+          <xsl:if test=".//cei:issued/cei:date/text() or .//cei:issued/cei:dateRange/text()">
+            <dcterms:issued>
+              <xsl:choose>
+                <xsl:when test=".//cei:issued/cei:date/@value != 99999999">
+                  <xsl:variable name="date" select=".//cei:issued/cei:date/@value" />
+                  <xsl:variable name="mm">
+                    <xsl:value-of select="substring($date,5,2)" />
+                  </xsl:variable>
+                  <xsl:variable name="dd">
+                    <xsl:value-of select="substring($date,7,2)" />
+                  </xsl:variable>
+                  <xsl:variable name="yyyy">
+                    <xsl:value-of select="substring($date,1,4)" />
+                  </xsl:variable>
+                  <xsl:value-of select="$yyyy" />
+                  <xsl:value-of select="'-'" />
+                  <xsl:value-of select="$mm" />
+                  <xsl:value-of select="'-'" />
+                  <xsl:value-of select="$dd" />
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:choose>
+                    <xsl:when test="(.//cei:issued/cei:dateRange/@from = .//cei:issued/cei:dateRange/@to) and (.//cei:issued/cei:dateRange/@from != '99999999')">
+                      <xsl:variable name="date" select=".//cei:issued/cei:dateRange/@from" />
+                      <xsl:variable name="mm">
+                        <xsl:value-of select="substring($date,5,2)" />
+                      </xsl:variable>
+                      <xsl:variable name="dd">
+                        <xsl:value-of select="substring($date,7,2)" />
+                      </xsl:variable>
+                      <xsl:variable name="yyyy">
+                        <xsl:value-of select="substring($date,1,4)" />
+                      </xsl:variable>
+                      <xsl:value-of select="$yyyy" />
+                      <xsl:value-of select="'-'" />
+                      <xsl:value-of select="$mm" />
+                      <xsl:value-of select="'-'" />
+                      <xsl:value-of select="$dd" />
+                    </xsl:when>
+                    <xsl:when test="(.//cei:issued/cei:dateRange/@from != .//cei:issued/cei:dateRange/@to) and (.//cei:issued/cei:dateRange/@from = '99999999')">
+                      <xsl:variable name="date_from" select=".//cei:issued/cei:dateRange/@from" />
+                      <xsl:variable name="date_to" select=".//cei:issued/cei:dateRange/@to" />
+                      <xsl:variable name="mm">
+                        <xsl:value-of select="substring($date_from,5,2)" />
+                      </xsl:variable>
+                      <xsl:variable name="dd">
+                        <xsl:value-of select="substring($date_from,7,2)" />
+                      </xsl:variable>
+                      <xsl:variable name="yyyy">
+                        <xsl:value-of select="substring($date_from,1,4)" />
+                      </xsl:variable>
+                      <xsl:value-of select="$yyyy" />
+                      <xsl:value-of select="'-'" />
+                      <xsl:value-of select="$mm" />
+                      <xsl:value-of select="'-'" />
+                      <xsl:value-of select="$dd" />
+                      <xsl:text> - </xsl:text>
+                      <xsl:variable name="mmt">
+                        <xsl:value-of select="substring($date_to,5,2)" />
+                      </xsl:variable>
+                      <xsl:variable name="ddt">
+                        <xsl:value-of select="substring($date_to,7,2)" />
+                      </xsl:variable>
+                      <xsl:variable name="yyyyt">
+                        <xsl:value-of select="substring($date_to,1,4)" />
+                      </xsl:variable>
+                      <xsl:value-of select="$yyyyt" />
+                      <xsl:value-of select="'-'" />
+                      <xsl:value-of select="$mmt" />
+                      <xsl:value-of select="'-'" />
+                      <xsl:value-of select="$ddt" />
+                    </xsl:when>
+                    <xsl:otherwise />
+                  </xsl:choose>
+                </xsl:otherwise>
+              </xsl:choose>
+            </dcterms:issued>
+          </xsl:if>
+        </edm:ProvidedCHO>
+      </rdf:RDF>
+    </oai:metadata>
+  </xsl:template>
+</xsl:stylesheet>

--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -48,21 +48,24 @@
     <!-- Create description from abstract and art-historical description -->
     <xsl:variable name="dc-description">
       <xsl:variable name="cei-abstract" select="normalize-space(.//cei:abstract)" />
-      <xsl:variable name="cei-decoDesc" select="normalize-space(.//cei:decoDesc)" />
-      <xsl:if test="$cei-abstract or $cei-decoDesc">
+      <xsl:variable name="cei-decoDesc-ekphrasis" select="normalize-space(.//cei:decoDesc/cei:p[@n='Ekphrasis'])" />
+      <xsl:variable name="cei-decoDesc-style" select="normalize-space(.//cei:decoDesc/cei:p[@n='Stil und Einordnung'])" />
+      <xsl:variable name="cei-decoDesc-author" select="normalize-space(.//cei:decoDesc/cei:p[@n='Autorensigle'])" />
+      <xsl:variable name="has-cei-decoDesc" select="$cei-decoDesc-ekphrasis or $cei-decoDesc-style or $cei-decoDesc-author" />
+      <xsl:if test="$cei-abstract or $has-cei-decoDesc">
         <dc:description>
           <xsl:if test="$cei-abstract">
-            <xsl:if test="$cei-decoDesc">
+            <xsl:if test="$has-cei-decoDesc">
               <xsl:text>Abstract: </xsl:text>
             </xsl:if>
             <xsl:value-of select="$cei-abstract" />
           </xsl:if>
-          <xsl:if test="$cei-decoDesc">
+          <xsl:if test="$has-cei-decoDesc">
             <xsl:if test="$cei-abstract">
               <xsl:text> — </xsl:text>
             </xsl:if>
             <xsl:text>Art-historical description: </xsl:text>
-            <xsl:value-of select="$cei-decoDesc" />
+            <xsl:value-of select="string-join(($cei-decoDesc-ekphrasis, $cei-decoDesc-style, $cei-decoDesc-author), ' — ') " />
           </xsl:if>
         </dc:description>
       </xsl:if>

--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -1,4 +1,4 @@
-<xsl:stylesheet id="cei2edm" version="1.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:cei="http://www.monasterium.net/NS/cei" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:ese="http://www.europeana.eu/schemas/ese/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:ore="http://www.openarchives.org/ore/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svcs="http://rdfs.org/sioc/services#" xmlns:xrx="http://www.mom-ca.uni-koeln.de/NS/xrx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform https://www.w3.org/2007/schema-for-xslt20.xsd">
+<xsl:stylesheet id="cei2edm" version="1.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:cei="http://www.monasterium.net/NS/cei" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:doap="http://usefulinc.com/ns/doap#" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:ese="http://www.europeana.eu/schemas/ese/" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:ore="http://www.openarchives.org/ore/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svcs="http://rdfs.org/sioc/services#" xmlns:xrx="http://www.mom-ca.uni-koeln.de/NS/xrx" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xsi:schemaLocation="http://www.w3.org/1999/XSL/Transform https://www.w3.org/2007/schema-for-xslt20.xsd">
   <xsl:param name="platform-id" />
   <xsl:param name="data-provider" />
   <xsl:param name="base-image-url" />
@@ -97,6 +97,7 @@
           <!-- Service for IIIF-->
           <svcs:Service rdf:about="{@base}">
             <dcterms:conformsTo rdf:resource="http://iiif.io/api/image" />
+            <doap:implements rdf:resource="http://iiif.io/api/image/2/level2.json" />
           </svcs:Service>
         </xsl:for-each>
         <!-- CHO -->

--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -24,6 +24,7 @@
           <!-- Connected CHO -->
           <edm:aggregatedCHO rdf:resource="{$provided-cho-id}" />
           <!-- Connected WebResources -->
+          <edm:isShownAt rdf:resource="{$aggregation-id}" />
           <xsl:for-each select="$image-ids/id">
             <xsl:sort select="@name" data-type="text" order="ascending" />
             <xsl:choose>
@@ -105,17 +106,17 @@
           <!-- Associated place names -->
           <xsl:if test=".//cei:placeName/text()">
             <xsl:for-each select=".//cei:abstract/cei:placeName">
-              <dc:spatial>
+              <dcterms:spatial>
                 <xsl:value-of select="./text()" />
-              </dc:spatial>
+              </dcterms:spatial>
             </xsl:for-each>
           </xsl:if>
           <!-- Associated geography names -->
           <xsl:if test=".//cei:geogName/text()">
             <xsl:for-each select=".//cei:geogName">
-              <dc:spatial>
+              <dcterms:spatial>
                 <xsl:value-of select="./text()" />
-              </dc:spatial>
+              </dcterms:spatial>
             </xsl:for-each>
           </xsl:if>
           <!-- Keywords -->

--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -16,6 +16,30 @@
         <id base="{concat($base-image-url, @url)}" name="{substring-before(@url, '.')}" iiif="{concat($base-image-url, @url, '/full/512,/0/default.jpg')}" />
       </xsl:for-each>
     </xsl:variable>
+    <!-- Create dc:rights and edm:rights statements -->
+    <xsl:variable name="dc-edm-rights">
+      <xsl:variable name="license-target" select=".//cei:license/@target" />
+      <xsl:variable name="license-text" select="normalize-space(.//cei:license)" />
+      <xsl:variable name="archive" select="normalize-space(//cei:witnessOrig/cei:archIdentifier/cei:arch)" />
+      <xsl:choose>
+        <xsl:when test="$license-target and $license-text">
+          <edm:rights rdf:resource="{$license-target}" />
+          <dc:rights>
+            <xsl:value-of select="$license-text" />
+          </dc:rights>
+        </xsl:when>
+        <xsl:when test="$archive">
+          <edm:rights rdf:resource="http://creativecommons.org/licenses/by-nc/4.0/" />
+          <dc:rights>
+            <xsl:value-of select="$archive" />
+          </dc:rights>
+        </xsl:when>
+        <xsl:otherwise>
+          <edm:rights rdf:resource="http://creativecommons.org/licenses/by-nc/4.0/" />
+          <dc:rights>Monasterium.net</dc:rights>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
     <!-- Create description from abstract and art-historical description -->
     <xsl:variable name="dc-description">
       <xsl:variable name="cei-abstract" select="normalize-space(.//cei:abstract)" />
@@ -58,8 +82,8 @@
               </xsl:otherwise>
             </xsl:choose>
           </xsl:for-each>
-          <!-- License -->
-          <edm:rights rdf:resource="http://creativecommons.org/licenses/by-nc/3.0/" />
+          <!-- License information -->
+          <xsl:copy-of select="$dc-edm-rights/*" />
           <!-- Data provider -->
           <edm:dataProvider>Monasterium.net</edm:dataProvider>
         </ore:Aggregation>
@@ -67,6 +91,7 @@
         <xsl:for-each select="$image-ids/id">
           <!-- Image webresource -->
           <edm:WebResource rdf:about="{@iiif}">
+            <!-- Image service -->
             <svcs:has_service rdf:resource="{@base}" />
           </edm:WebResource>
           <!-- Service for IIIF-->

--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -16,6 +16,25 @@
         <id base="{concat($base-image-url, @url)}" name="{substring-before(@url, '.')}" iiif="{concat($base-image-url, @url, '/full/512,/0/default.jpg')}" />
       </xsl:for-each>
     </xsl:variable>
+    <!-- Create description from abstract and art-historical description -->
+    <xsl:variable name="dc-description">
+      <xsl:variable name="cei-abstract" select="normalize-space(.//cei:abstract)" />
+      <xsl:variable name="cei-decoDesc" select="normalize-space(.//cei:decoDesc)" />
+      <xsl:if test="$cei-abstract or $cei-decoDesc">
+        <dc:description>
+          <xsl:if test="$cei-decoDesc">
+            <xsl:text>Abstract: </xsl:text>
+          </xsl:if>
+          <xsl:if test="$cei-abstract">
+            <xsl:value-of select="$cei-abstract" />
+          </xsl:if>
+          <xsl:if test="$cei-decoDesc">
+            <xsl:text>; Art-historical description: </xsl:text>
+            <xsl:value-of select="$cei-decoDesc" />
+          </xsl:if>
+        </dc:description>
+      </xsl:if>
+    </xsl:variable>
     <!-- Start OAI output -->
     <oai:metadata>
       <rdf:RDF>
@@ -65,12 +84,8 @@
           <dc:identifier>
             <xsl:value-of select=".//cei:idno" />
           </dc:identifier>
-          <!-- Abstract -->
-          <xsl:if test=".//cei:abstract/text()">
-            <dc:description>
-              <xsl:value-of select="normalize-space(.//cei:abstract)" />
-            </dc:description>
-          </xsl:if>
+          <!-- Description -->
+          <xsl:copy-of select="$dc-description" />
           <!-- Language -->
           <xsl:if test=".//cei:lang_MOM/text()">
             <dc:language>

--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -13,7 +13,7 @@
     </xsl:variable>
     <xsl:variable name="image-ids">
       <xsl:for-each select="//cei:graphic">
-        <id base="{concat($base-image-url, @url)}" iiif="{concat($base-image-url, @url, '/full/512,/0/default.jpg')}" />
+        <id base="{concat($base-image-url, @url)}" name="{substring-before(@url, '.')}" iiif="{concat($base-image-url, @url, '/full/512,/0/default.jpg')}" />
       </xsl:for-each>
     </xsl:variable>
     <!-- Start OAI output -->
@@ -25,10 +25,18 @@
           <edm:aggregatedCHO rdf:resource="{$provided-cho-id}" />
           <!-- Connected WebResources -->
           <xsl:for-each select="$image-ids/id">
-            <edm:isShownBy rdf:resource="{@iiif}" />
+            <xsl:sort select="@name" data-type="text" order="ascending" />
+            <xsl:choose>
+              <xsl:when test="position() = 1">
+                <edm:isShownBy rdf:resource="{@iiif}" />
+              </xsl:when>
+              <xsl:otherwise>
+                <edm:hasView rdf:resource="{@iiif}" />
+              </xsl:otherwise>
+            </xsl:choose>
           </xsl:for-each>
           <!-- License -->
-          <edm:rights rdf:resource="https://creativecommons.org/licenses/by-nc/3.0/" />
+          <edm:rights rdf:resource="http://creativecommons.org/licenses/by-nc/3.0/" />
           <!-- Data provider -->
           <edm:dataProvider>Monasterium.net</edm:dataProvider>
         </ore:Aggregation>


### PR DESCRIPTION
This adds support for the [EDM ](https://pro.europeana.eu/page/edm-documentation) to the available OAI-PMH `metadataPrefix` choices. It also adds the possibility to add license information (needed for EDM support) to the CEI XML Schema documents.