### PR TITLE
[OAI-PMH] Fix usage of dashes in EDM and wrong EDM title creation

### DIFF
--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -63,7 +63,7 @@
               <xsl:text> — </xsl:text>
             </xsl:if>
             <xsl:text>Art-historical description: </xsl:text>
-            <xsl:value-of select="string-join(($cei-decoDesc-ekphrasis, $cei-decoDesc-style, $cei-decoDesc-author), ' — ') " />
+            <xsl:value-of select="string-join(($cei-decoDesc-ekphrasis, $cei-decoDesc-style, $cei-decoDesc-author), ' – ') " />
           </xsl:if>
         </dc:description>
       </xsl:if>
@@ -114,7 +114,7 @@
         <edm:ProvidedCHO rdf:about="{$provided-cho-id}">
           <!-- Title -->
           <dc:title>
-            <xsl:value-of select="concat('Charter: ', $fond-id, ' ', .//cei:idno/@id)" />
+            <xsl:value-of select="concat('Charter: ', $parent-title, ' – ', .//cei:idno/@id)" />
           </dc:title>
           <!-- Types -->
           <dc:type>Charter</dc:type>


### PR DESCRIPTION
Fixes the following in the OAI-PMH EDM XSL

- The wrong kinds of dashes are used, change to en-dash
- The `dc:title` element used the fond id even if in was used for collection charters. This has been changed to use the parent title in all cases