### PR TITLE
[OAI-PMH] Replace edm single joint dc:description with individual ones

### DIFF
--- a/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
+++ b/my/XRX/src/mom/app/mom/xsl/cei2edm.xsl
@@ -50,21 +50,18 @@
       <xsl:variable name="cei-decoDesc-style" select="normalize-space(.//cei:decoDesc/cei:p[@n='Stil und Einordnung'])" />
       <xsl:variable name="cei-decoDesc-author" select="normalize-space(.//cei:decoDesc/cei:p[@n='Autorensigle'])" />
       <xsl:variable name="has-cei-decoDesc" select="$cei-decoDesc-ekphrasis or $cei-decoDesc-style or $cei-decoDesc-author" />
-      <xsl:if test="$cei-abstract or $has-cei-decoDesc">
+      <xsl:if test="$cei-abstract">
         <dc:description>
-          <xsl:if test="$cei-abstract">
-            <xsl:if test="$has-cei-decoDesc">
-              <xsl:text>Abstract: </xsl:text>
-            </xsl:if>
-            <xsl:value-of select="$cei-abstract" />
-          </xsl:if>
           <xsl:if test="$has-cei-decoDesc">
-            <xsl:if test="$cei-abstract">
-              <xsl:text> — </xsl:text>
-            </xsl:if>
-            <xsl:text>Art-historical description: </xsl:text>
-            <xsl:value-of select="string-join(($cei-decoDesc-ekphrasis, $cei-decoDesc-style, $cei-decoDesc-author), ' – ') " />
+            <xsl:text>Abstract: </xsl:text>
           </xsl:if>
+          <xsl:value-of select="$cei-abstract" />
+        </dc:description>
+      </xsl:if>
+      <xsl:if test="$has-cei-decoDesc">
+        <dc:description>
+          <xsl:text>Art-historical description: </xsl:text>
+          <xsl:value-of select="string-join(($cei-decoDesc-ekphrasis, $cei-decoDesc-style, $cei-decoDesc-author), ' – ') " />
         </dc:description>
       </xsl:if>
     </xsl:variable>


### PR DESCRIPTION
Changes the way `dc:descripion` elements are modelled in *EDM*. After consultation with Kulturpool, it seemed better to add the art-historical description (mainly for Illurk) as its own element instead of concatenating it with the abstract. This only affects charters that have an art-historical description.

Before: 
```xml
  <dc:description>Abstract: Bischofsammelindulgenz: Die Bischöfe Lambert von Aquino, Matheus von Veglia,
	 Stephanus und Romanus verleihen für die Marienkirche in Unlingen für genannte Sonn-
	 und Feiertage vierzigtägigen Ablass. (nach Archivdatenbank). — Art-historical description:
	 Leicht vergrösserte, ganz schmucklose Initiale U(niversis) zu Beginn des Textes. –
	 Sammelablässe, deren Initialen gar keinen Dekor - nicht einmal einfache, aus dem Buchstabenkörper
	 ausgesparte Linien - aufweisen, gehören nach 1295 schon zur Ausnahme. Eine sehr ähnliche
	 Initiale findet sich 1299 März erhalten. – Martin Roland
  </dc:description>
```
After:
```xml
  <dc:description>Abstract: Bischofsammelindulgenz: Die Bischöfe Lambert von Aquino, Matheus von Veglia,
	 Stephanus und Romanus verleihen für die Marienkirche in Unlingen für genannte Sonn-
	 und Feiertage vierzigtägigen Ablass. (nach Archivdatenbank).
  </dc:description>
  <dc:description>Art-historical description: Leicht vergrösserte, ganz schmucklose Initiale U(niversis)
	 zu Beginn des Textes. – Sammelablässe, deren Initialen gar keinen Dekor - nicht einmal
	 einfache, aus dem Buchstabenkörper ausgesparte Linien - aufweisen, gehören nach 1295
	 schon zur Ausnahme. Eine sehr ähnliche Initiale findet sich 1299 März erhalten. –
	 Martin Roland
  </dc:description>
```