### PR TITLE
update for #1195

### DIFF
--- a/my/XRX/src/mom/app/charter/widget/charter.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/charter.widget.xml
@@ -252,6 +252,10 @@ it leaves the active development stage.
       <xrx:name>$wcharter:anchor</xrx:name>
       <xrx:expression>if($xrx:tokenized-uri[last()] = 'charter') then charter:anchor(xs:integer($wcharter:pos)) else 1</xrx:expression>
     </xrx:variable>
+    <xrx:variable>
+      <xrx:name>$wcharter:volltext-bibl</xrx:name>
+      <xrx:expression>$wcharter:charter//cei:front/cei:sourceDesc/cei:sourceDescVolltext[cei:bibl//normalize-space() != '']</xrx:expression>
+    </xrx:variable>
     <!-- fond or collection information -->
     <xrx:variable>
       <xrx:name>$wcharter:linked-fond-base-collection</xrx:name>

--- a/my/XRX/src/mom/app/charter/widget/how-to-cite.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/how-to-cite.widget.xml
@@ -47,7 +47,12 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
 	  <div id="howToCite" style="display:none">
 	    <div class="p">
 	      <p>
-	        <span>{ for $archive in $wcharter:archive return concat($archive, ',&#160;') }{ $wcharter:fond }&#160;{ $wcharter:idno }, in: Monasterium.net, URL &lt;https://www.monasterium.net{ $wcharter:default-url }/charter&gt;, accessed { current-date() }</span>
+	        <span>
+	          { for $archive in $wcharter:archive return concat($archive, ',&#160;') }
+	          { $wcharter:fond }&#160;{ $wcharter:idno },
+	          { if ($wcharter:volltext-bibl) then concat('description/edition based on:', '&#160;', string-join(for $bibl in $wcharter:volltext-bibl/cei:bibl[text() != ''] return normalize-space(string-join($bibl//text())), ', ')) else () }
+	          in: Monasterium.net, URL &lt;https://www.monasterium.net{ $wcharter:default-url }/charter&gt;, accessed { current-date() }
+	        </span>
 	      </p>
 	    </div>
 	  </div>

--- a/my/XRX/src/mom/app/charter/widget/my-charter.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/my-charter.widget.xml
@@ -159,6 +159,10 @@ it leaves the active development stage.
       <xrx:name>$wcharter:pos</xrx:name>
       <xrx:expression>charter:position($wcharter:charters, $wcharter:private-charter, $xrx:user-xml, $wcharter:atom-id, $xrx:tokenized-uri[last()])</xrx:expression>
     </xrx:variable>
+    <xrx:variable>
+      <xrx:name>$wcharter:volltext-bibl</xrx:name>
+      <xrx:expression>$wcharter:charter//cei:front/cei:sourceDesc/cei:sourceDescVolltext[cei:bibl//normalize-space() != '']</xrx:expression>
+    </xrx:variable>
     <!-- 
       back link to fond or collection 
     -->

--- a/my/XRX/src/mom/app/charter/widget/saved-charter.widget.xml
+++ b/my/XRX/src/mom/app/charter/widget/saved-charter.widget.xml
@@ -147,6 +147,10 @@ it leaves the active development stage.
       <xrx:name>$wcharter:pos</xrx:name>
       <xrx:expression>charter:position($wcharter:charters, $wcharter:charter, $xrx:user-xml, $wcharter:atom-id, $xrx:tokenized-uri[last()])</xrx:expression>
     </xrx:variable>
+    <xrx:variable>
+      <xrx:name>$wcharter:volltext-bibl</xrx:name>
+      <xrx:expression>$wcharter:charter//cei:front/cei:sourceDesc/cei:sourceDescVolltext[cei:bibl//normalize-space() != '']</xrx:expression>
+    </xrx:variable>
         <!--
 		  back link to fond or collection
 		-->


### PR DESCRIPTION
Should finally correct #1195 without issue.
@StephanMa I believe the problem with #1205 was that only the updated how-to-cite.widget.xml was included after the initial reversion, so the `$wcharter:volltext-bibl` variable was not set, which caused the error. This should include everything.
