### PR TITLE
removed 'P_' pattern & introduce file identifier in person index

### DIFF
--- a/my/XRX/src/mom/app/index/index.xqm
+++ b/my/XRX/src/mom/app/index/index.xqm
@@ -69,9 +69,9 @@ In the person index a specific value in the @key is searched
 in other index a specific value in the @lemma is searched in the public collection
 :)
 
-declare function index:index-abfrage($term){
+declare function index:index-abfrage($term, $mode){
       let $treffergesamt := 
-          if (starts-with($term, 'P_')) then $index:chartercollection//cei:text[.//@key = $term] 
+          if ($mode = 'person') then $index:chartercollection//cei:text[.//@key = $term] 
           else( let $mehr :=  for $jeweils in index:narrower($term)
                               let $st := if(starts-with($jeweils, '#') ) then substring-after($jeweils, '#') else($jeweils)
                               return $index:chartercollection//cei:text[.//@lemma = $st]                   

--- a/my/XRX/src/mom/app/index/index.xqm
+++ b/my/XRX/src/mom/app/index/index.xqm
@@ -69,9 +69,9 @@ In the person index a specific value in the @key is searched
 in other index a specific value in the @lemma is searched in the public collection
 :)
 
-declare function index:index-abfrage($term, $mode){
+declare function index:index-abfrage($term, $coll){
       let $treffergesamt := 
-          if ($mode = 'person') then $index:chartercollection//cei:text[.//@key = $term] 
+          if ($coll = 'person') then $index:chartercollection//cei:text[.//@key = $term] 
           else( let $mehr :=  for $jeweils in index:narrower($term)
                               let $st := if(starts-with($jeweils, '#') ) then substring-after($jeweils, '#') else($jeweils)
                               return $index:chartercollection//cei:text[.//@lemma = $st]                   

--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -72,7 +72,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
     </xrx:variable>        
    <xrx:variable>
      <xrx:name>$windex:index</xrx:name>
-     <xrx:expression>if($coll = 'person') then index:index-abfrage($indexterm, 'person') else if($xrx:tokenized-uri[3]!= '#') then index:index-abfrage($indexterm, 'default') else()</xrx:expression>
+     <xrx:expression>if($coll = 'person') then index:index-abfrage($indexterm, 'person') else if($xrx:tokenized-uri[3]!= '#') then index:index-abfrage($indexterm, 'controlledVocabulary') else()</xrx:expression>
    </xrx:variable>
     <xrx:variable>
     <xrx:name>$windex:hits</xrx:name>

--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -70,10 +70,10 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
       <xrx:name>$indexterm</xrx:name>
       <xrx:expression>if(not(exists($xrx:tokenized-uri[3]))) then '' else if($coll = 'person') then concat($voc, ':', $xrx:tokenized-uri[3]) else (concat('#', $xrx:tokenized-uri[3]))</xrx:expression>
     </xrx:variable>        
-    <xrx:variable>    
-      <xrx:name>$windex:index</xrx:name>
-      <xrx:expression>if($xrx:tokenized-uri[3]!= '#') then index:index-abfrage($indexterm, 'person') else()</xrx:expression>
-    </xrx:variable>
+   <xrx:variable>
+     <xrx:name>$windex:index</xrx:name>
+     <xrx:expression>if($coll = 'person') then index:index-abfrage($indexterm, 'person') else if($xrx:tokenized-uri[3]!= '#') then index:index-abfrage($indexterm, 'default') else()</xrx:expression>
+   </xrx:variable>
     <xrx:variable>
     <xrx:name>$windex:hits</xrx:name>
     <xrx:expression>count($windex:index)</xrx:expression>

--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -68,7 +68,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
      </xrx:variable>
      <xrx:variable>
       <xrx:name>$indexterm</xrx:name>
-      <xrx:expression>if(not(exists($xrx:tokenized-uri[3]))) then '' else if($coll = 'person') then $xrx:tokenized-uri[3] else (concat('#', $xrx:tokenized-uri[3]))</xrx:expression>
+      <xrx:expression>if(not(exists($xrx:tokenized-uri[3]))) then '' else if($coll = 'person') then concat($voc, ':', $xrx:tokenized-uri[3]) else (concat('#', $xrx:tokenized-uri[3]))</xrx:expression>
     </xrx:variable>        
     <xrx:variable>    
       <xrx:name>$windex:index</xrx:name>

--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -59,12 +59,20 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
     </xrx:variable>
      <!-- suchergebnisse -->
      <xrx:variable>
+       <xrx:name>$voc</xrx:name>
+       <xrx:expression>$xrx:tokenized-uri[2]</xrx:expression>
+     </xrx:variable>   
+     <xrx:variable>
+       <xrx:name>$coll</xrx:name>
+       <xrx:expression>if(index:index-check($voc))then ('person') else('controlledVocabulary')</xrx:expression>
+     </xrx:variable>
+     <xrx:variable>
       <xrx:name>$indexterm</xrx:name>
-      <xrx:expression>if(not(exists($xrx:tokenized-uri[3]))) then '' else if(starts-with($xrx:tokenized-uri[3], 'P_')) then $xrx:tokenized-uri[3] else (concat('#', $xrx:tokenized-uri[3]))</xrx:expression>
+      <xrx:expression>if(not(exists($xrx:tokenized-uri[3]))) then '' else if($coll = 'person') then $xrx:tokenized-uri[3] else (concat('#', $xrx:tokenized-uri[3]))</xrx:expression>
     </xrx:variable>        
     <xrx:variable>    
       <xrx:name>$windex:index</xrx:name>
-      <xrx:expression>if($xrx:tokenized-uri[3]!= '#') then index:index-abfrage($indexterm) else()</xrx:expression>
+      <xrx:expression>if($xrx:tokenized-uri[3]!= '#') then index:index-abfrage($indexterm, 'person') else()</xrx:expression>
     </xrx:variable>
     <xrx:variable>
     <xrx:name>$windex:hits</xrx:name>
@@ -115,15 +123,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
    <xrx:name>$alphabet</xrx:name>
    <xrx:expression>('A', 'B','C','D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y','Z', 'A-Z')</xrx:expression>
    </xrx:variable>
-   <xrx:variable>
-   <xrx:name>$voc</xrx:name>
-   <xrx:expression>$xrx:tokenized-uri[2]</xrx:expression>
-   </xrx:variable>   
-      <xrx:variable>
-   <xrx:name>$coll</xrx:name>
-   <xrx:expression>if(index:index-check($voc))then ('person') else('controlledVocabulary')</xrx:expression>
-   </xrx:variable>
-      <xrx:variable>
+    <xrx:variable>
    <xrx:name>$atomid</xrx:name>
    <xrx:expression>concat('tag:www.monasterium.net,2011:/',$coll,'/', $voc)</xrx:expression>
    </xrx:variable>
@@ -839,7 +839,7 @@ ul.namelist {{
                 let $name := $person/tei:persName (: [starts-with(., $parameter)] :)
                 let $place := if ($name/following-sibling::tei:occupation/tei:placeName[1]/text()) then $name/following-sibling::tei:occupation/tei:placeName[1]/text() 
                 else()
-                let $aufbereitung := if($place) then substring-before(serialize($place), ' ') else(concat(' (', substring-after($personid, 'P_'), ')'))
+                let $aufbereitung := if($place) then substring-before(serialize($place), ' ') else(concat(' (', $personid, ')'))
                 let $inhalt := concat(string-join($name//text()/normalize-space(), ' '), ' ', $aufbereitung)
                 let $memo := if($personid != "") then session:set-attribute($personid, $inhalt) else ()
                 for $n in  $name                

--- a/my/XRX/src/mom/app/search/widget/result.widget.xml
+++ b/my/XRX/src/mom/app/search/widget/result.widget.xml
@@ -161,13 +161,6 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
       <xrx:name>$wcharter-preview:num-images</xrx:name>
       <xrx:expression>count($constructor:charter//cei:graphic/@url)</xrx:expression>
     </xrx:variable>
-    <!-- needed for the index app, show hits in xml-code -->
-      <xrx:variable>
-      <xrx:name>$exzerpt</xrx:name>
-      <xrx:expression>if(exists($terminus) and starts-with($terminus, 'P_')) then serialize($constructor:charter//cei:abstract/node())
-      else if($vocabular = 'illurk-vocabulary') then serialize($constructor:charter//cei:text/cei:back/node()) else(serialize($constructor:charter//cei:decoDesc//cei:p/node()))</xrx:expression>
-    </xrx:variable>
-    <!-- -->
     <xrx:variable>
       <xrx:name>$wcharter-preview:date</xrx:name>
       <xrx:expression>($constructor:charter//cei:date/text(), $constructor:charter//cei:dateRange/text(), data($constructor:charter//cei:date/@value), data($constructor:charter//cei:dateRange/@from))[1]</xrx:expression>


### PR DESCRIPTION
Replaces usage of the 'P_' pattern in person ids with check for location of the file (`metadata.person.public`) and the file identifier prefix from #949. The reference in result.widget.xml is no longer in use and is therefore removed completely.

Closes #1142 and, upon insertion of the prefix into existing charters, #951. 
Related issue #941 will be fixed separately.