### PR TITLE
list only first name in index view

### DIFF
--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -836,13 +836,12 @@ ul.namelist {{
                 order by $person/descendant::text()[normalize-space()][1]
                 return
                 let $personid := data($person/@xml:id)
-                let $name := $person/tei:persName (: [starts-with(., $parameter)] :)
+                let $name := $person/tei:persName[1] (: show only first persName, [starts-with(., $parameter)] :)
                 let $place := if ($name/following-sibling::tei:occupation/tei:placeName[1]/text()) then $name/following-sibling::tei:occupation/tei:placeName[1]/text() 
                 else()
                 let $aufbereitung := if($place) then substring-before(serialize($place), ' ') else(concat(' (', $personid, ')'))
                 let $inhalt := concat(string-join($name//text()/normalize-space(), ' '), ' ', $aufbereitung)
                 let $memo := if($personid != "") then session:set-attribute($personid, $inhalt) else ()
-                for $n in  $name                
                 return                                      
                 <li class="list">                
                 <a href="{concat(conf:param('request-root'),'index/', $voc, '/', $personid)}">{$inhalt}</a>


### PR DESCRIPTION
Use only the first `tei:persName` for a given `tei:person` to create a list entry in the index, to prevent the same person from being listed multiple times.
Lists of alternate labels in the person entry, and possibly support for something like `tei:persName[@type='prefLabel']` could be considered in the future if it makes sense for new indicies, but is not necessary for the current material.

Closes #1144.