### PR TITLE
generalize charter view separation of children of archIdentifier

### DIFF
--- a/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
+++ b/my/XRX/src/mom/app/charter/xsl/cei2html.xsl
@@ -1418,7 +1418,7 @@
         <xsl:apply-templates/>
         <br/>
     </xsl:template>
-    <xsl:template match="cei:arch | cei:institution | cei:settlement | cei:region | cei:country | cei:archFond">
+    <xsl:template match="cei:archIdentifier/*">
         <!--ignore existing final comma in element, add one if more elements follow-->
         <xsl:value-of select="normalize-space(replace(., ',$', ''))"/>
         <xsl:if test="following-sibling::*[1][. != '']">


### PR DESCRIPTION
Generalize proper separation of elements in charter view for all children of cei:archIdentifier (I should've done it this way initially...).

This is a follow-up to #558 and PR #1260