### PR TITLE
don't display SKOS editor if no corresponding vocab exists

### DIFF
--- a/my/XRX/src/mom/app/skos-editor/service/my-collection-release-skos.service.xml
+++ b/my/XRX/src/mom/app/skos-editor/service/my-collection-release-skos.service.xml
@@ -58,12 +58,8 @@
             <xrx:expression>$user-xml/xrx:moderator/text()</xrx:expression>
         </xrx:variable>
         <xrx:variable>
-            <xrx:name>$entry</xrx:name>
-            <xrx:expression>$xrx:user-xml//xrx:saved[xrx:id=$atomid]</xrx:expression>
-        </xrx:variable>
-        <xrx:variable>
             <xrx:name>$skos-to-release</xrx:name>
-            <xrx:expression>$entry/xrx:freigabe</xrx:expression>
+            <xrx:expression>$xrx:user-xml//xrx:saved[xrx:id=$atomid]/xrx:freigabe</xrx:expression>
         </xrx:variable>
     </xrx:variables>
     <xrx:emails>
@@ -95,32 +91,23 @@
     </xrx:emails>
     <xrx:body>
         {
-        let $success :=
-                <xrx:response>
-                    <xrx:status>200</xrx:status>
-                    <xrx:message>OK</xrx:message>
-                </xrx:response>
-        let $error :=
+        let $error := 
             <xrx:response>
-                <xrx:status>403</xrx:status>
-                <xrx:message>Not authorized</xrx:message>
+                <xrx:status>400</xrx:status>
+                <xrx:message>Bad Request</xrx:message>
             </xrx:response>
-        
-        return if ($session-username != 'guest') then (
-            let $updated := update replace $skos-to-release with <xrx:freigabe>yes</xrx:freigabe>
-            let $release-date := <xrx:released>{current-dateTime()}</xrx:released>
-            let $updated-released := update insert $release-date following $skos-to-release
-            return if ($skos-to-release/text() = 'yes' and $entry[$release-date]) then (
-             (: send email if document was stored :)
-             let $sendmail :=
-             <xrx:sendmail>
-                 <xrx:key>release-skos-email</xrx:key>
-             </xrx:sendmail>
-             return ($success)
-            )
-            else ($error)
+        let $success :=
+            <xrx:response>
+                <xrx:status>200</xrx:status>
+                <xrx:message>OK</xrx:message>
+            </xrx:response>
+        return if ($session-username = 'guest' or empty($skos-to-release)) then $error
+        else (
+            let $update-release := update replace $skos-to-release with <xrx:freigabe>yes</xrx:freigabe>
+            let $update-date := update insert <xrx:released>{current-dateTime()}</xrx:released> following $skos-to-release
+            let $sendmail := <xrx:sendmail> <xrx:key>release-skos-email</xrx:key> </xrx:sendmail>
+            return $success
         )
-        else ($error)
         }
     </xrx:body>
 </xrx:service>

--- a/my/XRX/src/mom/app/skos-editor/widget/skos-editor.widget.xml
+++ b/my/XRX/src/mom/app/skos-editor/widget/skos-editor.widget.xml
@@ -554,10 +554,25 @@
       <xrx:true>
         <xrx:view>
           <xrx:div>title-div</xrx:div>
-          <xrx:div>select-concept-div</xrx:div>
-          <xrx:div>preflabel-div</xrx:div>
-          <xrx:div>broader-div</xrx:div>
-          <xrx:div>description-div</xrx:div>
+          {
+          if ($vocab = '') then 
+          (
+            <div>No vocabulary selected.</div>
+          )
+          else if (empty($skosfile)) then
+          (
+            <div>Please create a private copy of this vocabulary to edit it.</div>
+          )
+          else
+          (
+            <div>
+              <xrx:div>select-concept-div</xrx:div>
+              <xrx:div>preflabel-div</xrx:div>
+              <xrx:div>broader-div</xrx:div>
+              <xrx:div>description-div</xrx:div>
+            </div>
+          )
+          }
         </xrx:view>
       </xrx:true>
       <xrx:false>


### PR DESCRIPTION
Closes #1129, also prevents release button potentially showing "Success" even though nothing happened.