### PR TITLE
[Bug] Add range indexes for atom:id and xrx:freigabe to improve query performance

### DIFF
--- a/my/XRX/system/config/db/mom-data/metadata.charter.public/collection.xconf
+++ b/my/XRX/system/config/db/mom-data/metadata.charter.public/collection.xconf
@@ -98,6 +98,7 @@
             <create qname="@from" type="xs:integer"/>
             <create qname="@to" type="xs:integer"/>
             <create qname="@value" type="xs:double"/>
+            <create qname="atom:id" type="xs:string"/>
         </range>
     </index>
 </collection>

--- a/my/XRX/system/config/db/mom-data/metadata.collection.public/collection.xconf
+++ b/my/XRX/system/config/db/mom-data/metadata.collection.public/collection.xconf
@@ -1,9 +1,12 @@
-<collection xmlns="http://exist-db.org/collection-config/1.0"> 
-    <index xmlns:cei="http://www.monasterium.net/NS/cei" xmlns:atom="http://www.w3.org/2005/Atom"> 
+<collection xmlns="http://exist-db.org/collection-config/1.0">
+    <index xmlns:cei="http://www.monasterium.net/NS/cei" xmlns:atom="http://www.w3.org/2005/Atom">
         <fulltext default="none" attributes="no"/>
         <lucene>
             <analyzer class="org.apache.lucene.analysis.standard.StandardAnalyzer"/>
             <text qname="cei:p" />
         </lucene>
-    </index> 
+        <range>
+            <create qname="atom:id" type="xs:string"/>
+        </range>
+    </index>
 </collection>

--- a/my/XRX/system/config/db/mom-data/xrx.user/collection.xconf
+++ b/my/XRX/system/config/db/mom-data/xrx.user/collection.xconf
@@ -5,6 +5,7 @@
             <create qname="xrx:email" type="xs:string"/>
             <create qname="xrx:id" type="xs:string"/>
             <create qname="atom:id" type="xs:string"/>
+            <create qname="xrx:freigabe" type="xs:string"/>
         </range>
   </index>
 </collection>


### PR DESCRIPTION

- metadata.charter.public: range index on atom:id for O(1) charter lookups
- metadata.collection.public: range index on atom:id for collection lookups
- xrx.user: range index on xrx:freigabe for publication status queries

Requires reindex of affected collections after deployment.