### PR TITLE
Remove my-collection-edit console outputs

### DIFF
--- a/my/XRX/src/mom/app/collection/js/jquery.ui.charterItems.js
+++ b/my/XRX/src/mom/app/collection/js/jquery.ui.charterItems.js
@@ -167,8 +167,6 @@ $.widget( "ui.charterItems", {
 	            .text("Editor") )
                 
               );
-          console.log('Das ist ein ajax test');
-          console.log(self._serviceUrl(serviceMyCollectionItems));
           var itemLinkDisplay = $('<div></div>')
               .addClass("forms-table-cell");
           if (versionOfTitle !== '') {

--- a/my/XRX/src/mom/app/collection/service/my-collections-tree-shared.service.xml
+++ b/my/XRX/src/mom/app/collection/service/my-collections-tree-shared.service.xml
@@ -54,7 +54,7 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
             let $tokens := tokenize(util:collection-name($shared), '/')
             let $collectionid := $tokens[last()]
             let $atomid := metadata:atomid('mycollection', $collectionid)
-            let $entry := $user:db-base-collection//atom:id[.=$atomid]/parent::atom:entry[cei:cei]
+            let $entry := $user:db-base-collection//atom:id[.=$atomid]/parent::atom:entry
             let $collection-name := $entry//cei:titleStmt/cei:title/text()
             order by $collection-name
             return

--- a/my/XRX/src/mom/app/collection/service/my-collections-tree-shared.service.xml
+++ b/my/XRX/src/mom/app/collection/service/my-collections-tree-shared.service.xml
@@ -54,7 +54,7 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
             let $tokens := tokenize(util:collection-name($shared), '/')
             let $collectionid := $tokens[last()]
             let $atomid := metadata:atomid('mycollection', $collectionid)
-            let $entry := $user:db-base-collection//atom:id[.=$atomid]/parent::atom:entry
+            let $entry := $user:db-base-collection//atom:id[.=$atomid]/parent::atom:entry[cei:cei]
             let $collection-name := $entry//cei:titleStmt/cei:title/text()
             order by $collection-name
             return


### PR DESCRIPTION
Makes sure my-collections-tree-shared only checks actual CEI collection files, and removes unneeded console outputs.

Closes #1281