### PR TITLE
performance optimizations for person index

### DIFF
--- a/my/XRX/src/mom/app/index/index.xqm
+++ b/my/XRX/src/mom/app/index/index.xqm
@@ -70,17 +70,16 @@ in other index a specific value in the @lemma is searched in the public collecti
 :)
 
 declare function index:index-abfrage($term, $coll){
-      let $charters := $index:chartercollection//cei:text
       let $all-hits := 
-          if ($coll = 'person') then $charters[.//cei:persName/@key = $term] 
+          if ($coll = 'person') then $index:chartercollection//cei:persName[@key = $term]/ancestor::cei:text[@type='charter']
           else (
-            let $lemma-hits := $charters[.//cei:index/@lemma = substring-after($term, '#')]
+            let $lemma-hits := $index:chartercollection//cei:index[@lemma = substring-after($term, '#')]/ancestor::cei:text[@type='charter']
             let $narrower-terms := 
                 for $n in index:narrower($term)
                 return if (starts-with($n, '#')) then substring-after($n, '#') else $n                  
             let $lemma-values := ($term, $narrower-terms)
             for $dlv in distinct-values($lemma-values)
-            return $charters[.//@lemma = $dlv]
+            return $index:chartercollection//@lemma[data() = $dlv]/ancestor::cei:text[@type='charter']
                 )            
       for $hit in $all-hits
         let $date := charters:date-selector($hit/cei:body/cei:chDesc/cei:issued, 'from')

--- a/my/XRX/src/mom/app/index/index.xqm
+++ b/my/XRX/src/mom/app/index/index.xqm
@@ -52,16 +52,6 @@ declare variable $index:vocabularycollection := collection(concat(conf:param("da
 declare variable $index:sprache := substring($xrx:lang, 0,3);
 
 
-
- declare function index:index-check($voc){
-    for $file in $index:personcollection   
-    let $file-lastname := tokenize($file//atom:id, '/')[last()]      
-    return
-     if ($file-lastname = $voc)
-     then true()
-     else()    
-};
-
 (: function searches hits of a lemma in @ of published charters. 
 and searches hits from narrower terms as well.
 It returns the entries (atom:entry):

--- a/my/XRX/src/mom/app/index/index.xqm
+++ b/my/XRX/src/mom/app/index/index.xqm
@@ -70,28 +70,27 @@ in other index a specific value in the @lemma is searched in the public collecti
 :)
 
 declare function index:index-abfrage($term, $coll){
-      let $treffergesamt := 
-          if ($coll = 'person') then $index:chartercollection//cei:text[.//@key = $term] 
-          else( let $mehr :=  for $jeweils in index:narrower($term)
-                              let $st := if(starts-with($jeweils, '#') ) then substring-after($jeweils, '#') else($jeweils)
-                              return $index:chartercollection//cei:text[.//@lemma = $st]                   
-                let $treffer := $index:chartercollection//cei:text[.//@lemma = substring-after($term, '#')]
-                return $treffer union $mehr
+      let $charters := $index:chartercollection//cei:text
+      let $all-hits := 
+          if ($coll = 'person') then $charters[.//@key = $term] 
+          else (
+            let $lemma-hits := $charters[.//@lemma = substring-after($term, '#')]
+            let $narrower-hits := for $n in index:narrower($term)
+                return if (starts-with($n, '#')) then substring-after($n, '#') else $n                  
+            return $lemma-hits union $narrower-hits
                 )            
-      for $treffer in $treffergesamt
-        let $date := charters:date-selector($treffer//cei:issued, 'from')
-        order by number($date) ascending
-        return 
-          $treffer/ancestor::atom:entry 
+      for $hit in $all-hits
+        let $date := charters:date-selector($hit//cei:issued, 'from')
+        order by number($date)
+        return $hit/ancestor::atom:entry 
 };
 
- 
- declare function index:narrower($term as xs:string) {
-           let $suchterm := if(starts-with($term, '#')) then  $term else (concat('#', $term))
-           let $voc := if( $index:vocabularycollection//skos:Concept[@rdf:about= $suchterm]/skos:narrower) then $index:vocabularycollection//skos:Concept[@rdf:about= $suchterm]/skos:narrower else ()
-           let $narrow := data($voc/@rdf:resource)          
-           return $narrow
- }; (: $narrow ist eine Sequenz an Strings, die auch gesucht werden sollen :)
+declare function index:narrower($term as xs:string) as xs:string* {
+  let $concepts := $index:vocabularycollection//skos:Concept
+  let $uri := if (starts-with($term, '#')) then $term else concat('#', $term)
+  let $voc := $concepts[@rdf:about = $uri]/skos:narrower
+  return data($voc/@rdf:resource)
+}; (: $narrow ist eine Sequenz an Strings, die auch gesucht werden sollen :)
  
 
 (: the following two functions are needed to cut TEI data in order to get a userfriendly representation of the text in the UI :)

--- a/my/XRX/src/mom/app/index/index.xqm
+++ b/my/XRX/src/mom/app/index/index.xqm
@@ -72,15 +72,18 @@ in other index a specific value in the @lemma is searched in the public collecti
 declare function index:index-abfrage($term, $coll){
       let $charters := $index:chartercollection//cei:text
       let $all-hits := 
-          if ($coll = 'person') then $charters[.//@key = $term] 
+          if ($coll = 'person') then $charters[.//cei:persName/@key = $term] 
           else (
-            let $lemma-hits := $charters[.//@lemma = substring-after($term, '#')]
-            let $narrower-hits := for $n in index:narrower($term)
+            let $lemma-hits := $charters[.//cei:index/@lemma = substring-after($term, '#')]
+            let $narrower-terms := 
+                for $n in index:narrower($term)
                 return if (starts-with($n, '#')) then substring-after($n, '#') else $n                  
-            return $lemma-hits union $narrower-hits
+            let $lemma-values := ($term, $narrower-terms)
+            for $dlv in distinct-values($lemma-values)
+            return $charters[.//@lemma = $dlv]
                 )            
       for $hit in $all-hits
-        let $date := charters:date-selector($hit//cei:issued, 'from')
+        let $date := charters:date-selector($hit/cei:body/cei:chDesc/cei:issued, 'from')
         order by number($date)
         return $hit/ancestor::atom:entry 
 };

--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -795,8 +795,8 @@ ul.namelist {{
               return
               if ($parameter != '') then
               let $personenliste := $index:personcollection/atom:entry[contains(atom:id, $voc)]//tei:listPerson
-              let $eintrag := if($parameter != '' and $parameter != 'A-Z') then $personenliste//tei:person[starts-with(descendant::text()[normalize-space()][1], $parameter)] 
-                              else if($parameter = 'A-Z') then $personenliste//tei:person
+              let $eintrag := if($parameter != '' and $parameter != 'A-Z') then $personenliste/tei:person[starts-with(descendant::text()[normalize-space()][1], $parameter)] 
+                              else if($parameter = 'A-Z') then $personenliste/tei:person
                               else()
 
               let $zahlen := count($eintrag)              
@@ -842,16 +842,16 @@ ul.namelist {{
          <ul class="choose-menu">
             {           
          for $i in $index:vocabularycollection
-         let $text := if($i//atom:content//skos:ConceptScheme/skos:prefLabel/@xml:lang = $sprache) 
-         then $i//atom:content//skos:ConceptScheme/skos:prefLabel[@xml:lang = $sprache]/text()
-         else($i//atom:content//skos:ConceptScheme/skos:prefLabel[1]/text())
+         let $text := if($i/atom:entry/atom:content/rdf:RDF/skos:ConceptScheme/skos:prefLabel/@xml:lang = $sprache) 
+         then $i/atom:entry/atom:content/rdf:RDF/skos:ConceptScheme/skos:prefLabel[@xml:lang = $sprache]/text()
+         else($i/atom:entry/atom:content/rdf:RDF/skos:ConceptScheme/skos:prefLabel[1]/text())
 
-         let $name := tokenize($i//atom:id/text(), '/')[last()]
+         let $name := tokenize($i/atom:entry/atom:id/text(), '/')[last()]
          let $memo := if($name != "") then session:set-attribute($name, $text) else ()
         
          return          
          
-         <li><a class="ui-button ui-widget ui-corner-all" href="{concat(conf:param('request-root'), 'index/',tokenize($i//atom:id/text(), 'controlledVocabulary/')[2])}">{$text}</a></li>
+         <li><a class="ui-button ui-widget ui-corner-all" href="{concat(conf:param('request-root'), 'index/',tokenize($i/atom:entry/atom:id/text(), 'controlledVocabulary/')[2])}">{$text}</a></li>
          
              
          }
@@ -859,15 +859,15 @@ ul.namelist {{
         
          for $p in $index:personcollection
          let $files := util:document-name($p)         
-         let $text := if($p//atom:content//tei:title[@xml:lang=$sprache]/text() !='')
-          then $p//atom:content//tei:title[@xml:lang=$sprache]/text()
-         else($p//atom:content//tei:title[1]/text())
-         let $name := tokenize($p//atom:id/text(), '/')[last()]         
+         let $text := if($p/atom:entry/atom:content//tei:title[@xml:lang=$sprache]/text() !='')
+          then $p/atom:entry/atom:content//tei:title[@xml:lang=$sprache]/text()
+         else($p/atom:entry/atom:content//tei:title[1]/text())
+         let $name := tokenize($p/atom:entry/atom:id/text(), '/')[last()]         
          let $memo := if($name != "") then session:set-attribute($name, $text) else ()
          
          return        
          
-         <li><a class="ui-button ui-widget ui-corner-all" href="{concat(conf:param('request-root'), 'index/',tokenize($p//atom:id/text(), 'person/')[2])}">{$text}</a></li>
+         <li><a class="ui-button ui-widget ui-corner-all" href="{concat(conf:param('request-root'), 'index/',tokenize($p/atom:entry/atom:id/text(), 'person/')[2])}">{$text}</a></li>
         
          
          }

--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -25,33 +25,6 @@ along with VdU/VRET.  If not, see http://www.gnu.org/licenses.
 We expect VdU/VRET to be distributed in the future with a license more lenient towards the inclusion of components into other systems, once it leaves the active development stage.
    </xrx:licence>
    <xrx:variables>
-      <!-- charter context information -->
-    <xrx:variable>
-      <xrx:name>$wcharters:metadata-charter-context-collection</xrx:name>
-      <xrx:expression>(metadata:base-collection('collection', $charter:rcollectionid, 'public')|metadata:base-collection('mycollection', $charter:rcollectionid, 'public'))</xrx:expression>
-    </xrx:variable>
-    <xrx:variable>
-      <xrx:name>$wcharters:metadata-charter-context-entry</xrx:name>
-      <xrx:expression>$wcharters:metadata-charter-context-collection//cei:cei/ancestor::atom:entry</xrx:expression>
-    </xrx:variable>
-    <xrx:variable>
-      <xrx:name>$wcharters:charter-context-name</xrx:name>
-      <xrx:expression>($wcharters:metadata-charter-context-entry//cei:provenance/text(),$wcharters:metadata-charter-context-entry//cei:titleStmt/cei:title/text())</xrx:expression>
-    </xrx:variable>
-    <xrx:variable>
-      <xrx:name>$wcharters:charter-context-short-name</xrx:name>
-      <xrx:expression>($wcharters:metadata-charter-context-entry//cei:provenance/@abbr/string(),$wcharters:charter-context-name)[1]</xrx:expression>
-    </xrx:variable>
-    <!-- linked archival fonds -->
-    <xrx:variable>
-      <xrx:name>$wcharters:linked-fond-charter-base-collection</xrx:name>
-      <xrx:expression>mycollection:linked-fond-charter-base-collection($wcharters:metadata-charter-context-collection)</xrx:expression>
-    </xrx:variable>
-    <!-- charter base collection -->
-    <xrx:variable>
-      <xrx:name>$wcharters:metadata-charter-collection</xrx:name>
-      <xrx:expression>(metadata:base-collection('charter', $charter:rcollectionid, 'public'), $wcharters:linked-fond-charter-base-collection)</xrx:expression>
-    </xrx:variable>
     <!-- block-wise navigation -->
     <xrx:variable>
       <xrx:name>$windex:block</xrx:name><!-- schon angepasst -->
@@ -104,13 +77,8 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
       <xrx:expression>if($windex:block = $windex:hits div 30) then 1 else $windex:block + 1</xrx:expression>
     </xrx:variable> 
     
-    <!-- var $setresults speichert die suchergebnisse (ganze atom:entrys),
-    Sortierung der Suchergebnisse passiert in index.xqm,
+    <!-- Sortierung der Suchergebnisse passiert in index.xqm,
      dann kann in der korrekten Reihefolge geblättert werden (browse search results)-->
-    <xrx:variable>
-    <xrx:name>$setresults</xrx:name>
-    <xrx:expression>if ($search:RESULT) then session:set-attribute($search:RESULT, $windex:index) else () </xrx:expression>
-    </xrx:variable> 
     <xrx:variable>
       <xrx:name>$index-use-text</xrx:name>
       <xrx:expression>htdoc:process(htdoc:get('tag:www.monasterium.net,2011:/mom/htdoc/index-use'))</xrx:expression>
@@ -133,16 +101,16 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
    </xrx:variable>
        <xrx:variable>
    <xrx:name>$vocabulary</xrx:name>
-   <xrx:expression>collection($momcollpath)/atom:entry[atom:id/text()= $atomid]</xrx:expression>
+   <xrx:expression>collection($momcollpath)/atom:entry[atom:id/text()= $atomid]/atom:content</xrx:expression>
    </xrx:variable>
    <xrx:variable>
    <xrx:name>$breadcrumb1</xrx:name>
-   <xrx:expression> if($coll = 'person') then if($vocabulary//tei:titleStmt/tei:title/@xml:lang = $sprache) 
-                                                  then $vocabulary//tei:titleStmt/tei:title[@xml:lang = $sprache]/text() 
-                                                  else($vocabulary//tei:titleStmt/tei:title[1]/text())
-                        else ( if($vocabulary//skos:ConceptScheme/skos:prefLabel/@xml:lang = $sprache)then 
-                             $vocabulary//skos:ConceptScheme/skos:prefLabel[@xml:lang= $sprache]/text()
-                            else($vocabulary//skos:ConceptScheme/skos:prefLabel[1]/text()))
+   <xrx:expression> if($coll = 'person') then if($vocabulary/tei:TEI/tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title/@xml:lang = $sprache) 
+                                                  then $vocabulary/tei:TEI/tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title[@xml:lang = $sprache]/text() 
+                                                  else($vocabulary/tei:TEI/tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title[1]/text())
+                        else ( if($vocabulary/rdf:RDF/skos:ConceptScheme/skos:prefLabel/@xml:lang = $sprache)then 
+                             $vocabulary/rdf:RDF/skos:ConceptScheme/skos:prefLabel[@xml:lang= $sprache]/text()
+                            else($vocabulary/rdf:RDF/skos:ConceptScheme/skos:prefLabel[1]/text()))
     </xrx:expression>
    </xrx:variable>
    <xrx:variable>
@@ -783,9 +751,9 @@ ul.namelist {{
               <xrx:default>Choose a lemma</xrx:default>
             </xrx:i18n>:</h2>         
            {                   
-         if ($vocabulary//skos:hasTopConcept) then                
-                 for $top in $vocabulary//skos:hasTopConcept
-                 let $allPrefLabels := $vocabulary//skos:Concept[@rdf:about= data($top/@rdf:resource)]/skos:prefLabel
+              if ($vocabulary/rdf:RDF/skos:ConceptScheme/skos:hasTopConcept) then                
+                 for $top in $vocabulary/rdf:RDF/skos:ConceptScheme/skos:hasTopConcept
+                 let $allPrefLabels := $vocabulary/rdf:RDF/skos:Concept[@rdf:about= data($top/@rdf:resource)]/skos:prefLabel
                  let $prefLabel := if($allPrefLabels[@xml:lang=$sprache]) then ($allPrefLabels[@xml:lang=$sprache]) else ($allPrefLabels[1])
                  let $label1 := <a>{ $prefLabel}</a>
                  let $rdfabout1 := data($top/@rdf:resource)
@@ -800,8 +768,8 @@ ul.namelist {{
           else if($coll != 'person') then
           <ul>
           {
-              if ($vocabulary//skos:Concept) then               
-              for $g in $vocabulary//skos:Concept
+              if ($vocabulary/rdf:RDF/skos:Concept) then               
+              for $g in $vocabulary/rdf:RDF/skos:Concept
               let $rdfabout := substring-after(data($g/@rdf:about), '#')
 
               let $label:= if ($g/prefLabel/@xml:lang= $sprache) then $g/prefLabel[@xml:lang= $sprache]/text() else($g/skos:prefLabel[1]/text())
@@ -910,11 +878,10 @@ ul.namelist {{
     
     
     else if($teile = 2) then 
-    let $note := if($coll = 'person') then transform:transform($vocabulary//tei:sourceDesc, $foreword-xsl, ())
-                 else(if ($vocabulary//skos:ConceptScheme/skos:note[@xml:lang=$sprache]/node()) 
-                      then $vocabulary//skos:ConceptScheme/skos:note[@xml:lang=$sprache]/node()
-                      else($vocabulary//skos:ConceptScheme/skos:note[1]/node())   
-                      )
+    let $note := if($coll = 'person') then transform:transform($vocabulary/tei:TEI/tei:teiHeader/tei:fileDesc/tei:sourceDesc/node(), $foreword-xsl, ())
+                 else(if ($vocabulary/rdf:RDF/skos:ConceptScheme/skos:note[@xml:lang=$sprache]/node()) 
+                      then $vocabulary/rdf:RDF/skos:ConceptScheme/skos:note[@xml:lang=$sprache]/node()
+                      else($vocabulary/rdf:RDF/skos:ConceptScheme/skos:note[1]/node()))
 
     return
 
@@ -929,16 +896,16 @@ ul.namelist {{
     <div id="rightframe">
       {  
       
-      if ($teile = 3 and $vocabulary//skos:Concept) then
-       (: let $breadcrumb1:= if ($vocabulary//skos:ConceptScheme/skos:prefLabel/@xml:lang = $sprache)then 
-                             $vocabulary//skos:ConceptScheme/skos:prefLabel[@xml:lang= $sprache]/text()
-                            else($vocabulary//skos:ConceptScheme/skos:prefLabel[1]/text()) 
+      if ($teile = 3 and $vocabulary/rdf:RDF/skos:Concept) then
+       (: let $breadcrumb1:= if ($vocabulary/rdf:RDF/skos:ConceptScheme/skos:prefLabel/@xml:lang = $sprache)then 
+                             $vocabulary/rdf:RDF/skos:ConceptScheme/skos:prefLabel[@xml:lang= $sprache]/text()
+                            else($vocabulary/rdf:RDF/skos:ConceptScheme/skos:prefLabel[1]/text()) 
                             :)
         let $term := concat('#', $xrx:tokenized-uri[3])
-        let $breadcrumb2 := if ($vocabulary//skos:Concept[@rdf:about = $term]/skos:prefLabel/@xml:lang = $sprache)then 
-                             $vocabulary//skos:Concept[@rdf:about = $term]/skos:prefLabel[@xml:lang= $sprache]/text()
-                            else($vocabulary//skos:Concept[@rdf:about = $term]/skos:prefLabel[1]/text())
-        let $beschreibung:= $vocabulary//skos:Concept[@rdf:about = $term]/skos:definition/node()
+        let $breadcrumb2 := if ($vocabulary/rdf:RDF/skos:Concept[@rdf:about = $term]/skos:prefLabel/@xml:lang = $sprache)then 
+                             $vocabulary/rdf:RDF/skos:Concept[@rdf:about = $term]/skos:prefLabel[@xml:lang= $sprache]/text()
+                            else($vocabulary/rdf:RDF/skos:Concept[@rdf:about = $term]/skos:prefLabel[1]/text())
+        let $beschreibung:= $vocabulary/rdf:RDF/skos:Concept[@rdf:about = $term]/skos:definition/node()
         let $anzahlknoten := count($beschreibung)
         let $glossar := <div class="entry">{$beschreibung}</div>
        (: wenn die Beschreibung länger ist, soll ein Pfeil gesetzt werden, der anzeigt, dass noch mehr Info da ist :)
@@ -976,10 +943,10 @@ ul.namelist {{
       
       else(
       let $term := $xrx:tokenized-uri[3]
-      let $breadcrumb1 := if($vocabulary//tei:titleStmt/tei:title/@xml:lang = $sprache) then $vocabulary//tei:titleStmt/tei:title[@xml:lang = $sprache]/text() 
-                          else($vocabulary//tei:titleStmt/tei:title[1]/text())    
-      let $glossar := string-join($vocabulary//tei:person[@xml:id = $term]//text()/normalize-space(), ' ') 
-      let $persname := replace(string-join($vocabulary//tei:person[@xml:id = $term]/tei:persName//text()/normalize-space(), ' '), ',', '')
+      let $breadcrumb1 := if($vocabulary/tei:TEI/tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title/@xml:lang = $sprache) then $vocabulary/tei:TEI/tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title[@xml:lang = $sprache]/text() 
+                          else($vocabulary/tei:TEI/tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title[1]/text())    
+      let $glossar := string-join($vocabulary/tei:TEI/tei:text/tei:body/tei:listPerson/tei:person[@xml:id = $term]//text()/normalize-space(), ' ') 
+      let $persname := replace(string-join($vocabulary/tei:TEI/tei:text/tei:body/tei:listPerson/tei:person[@xml:id = $term]/tei:persName//text()/normalize-space(), ' '), ',', '')
       let $persname := if (string-length($persname) gt 15) then concat(substring($persname, 0, 15), '...') else $persname
       let $from := ('([0-9])([A-Z])', '([a-z])([A-Z])', '([a-z])(\()', '(.)([A-Z])', '(,)([a-z][A-Z])', '(\))([0-9a-zA-Z])', '(\()(\s)' )
       let $to := ('$1 $2', '$1 $2', '$1 $2', '$1 $2', '. $2', '$1 $2', '$1')      

--- a/my/XRX/src/mom/app/index/widget/index.widget.xml
+++ b/my/XRX/src/mom/app/index/widget/index.widget.xml
@@ -37,7 +37,7 @@ We expect VdU/VRET to be distributed in the future with a license more lenient t
      </xrx:variable>   
      <xrx:variable>
        <xrx:name>$coll</xrx:name>
-       <xrx:expression>if(index:index-check($voc))then ('person') else('controlledVocabulary')</xrx:expression>
+       <xrx:expression>if(exists($index:personcollection/atom:entry/atom:id[ends-with(., concat('/', $voc))])) then ('person') else('controlledVocabulary')</xrx:expression>
      </xrx:variable>
      <xrx:variable>
       <xrx:name>$indexterm</xrx:name>

--- a/my/XRX/system/config/db/mom-data/metadata.charter.public/collection.xconf
+++ b/my/XRX/system/config/db/mom-data/metadata.charter.public/collection.xconf
@@ -99,6 +99,8 @@
             <create qname="@to" type="xs:integer"/>
             <create qname="@value" type="xs:double"/>
             <create qname="atom:id" type="xs:string"/>
+            <create qname="@key" type="xs:string"/>
+            <create qname="cei:persName" type="xs:string"/>
         </range>
     </index>
 </collection>


### PR DESCRIPTION
Does the following:

- replaces descendant axes (//) with exact paths where possible
- adds index support for `cei:persName` and `@key` and changes some queries to make better use of them
- rewrites some code for efficiency
- also removes some old, unused code and changes some names for clarity

At least locally this leads to a 30% - 50% speed-up - remains to be seen how much of this translates to live.

Should close #1059